### PR TITLE
Support multiple "python qt" api names

### DIFF
--- a/pyqode/core/panels/folding.py
+++ b/pyqode/core/panels/folding.py
@@ -9,7 +9,7 @@ from pyqode.core.api import TextBlockHelper, folding, TextDecoration, \
     DelayJobRunner
 from pyqode.core.api.folding import FoldScope
 from pyqode.core.api.panel import Panel
-from pyqode.qt import QtCore, QtWidgets, QtGui
+from pyqode.qt import QtCore, QtWidgets, QtGui, PYQT5_API
 from pyqode.core.api.utils import TextHelper, drift_color, keep_tc_pos
 
 
@@ -19,6 +19,7 @@ def _logger():
 
 
 class FoldingPanel(Panel):
+
     """ Displays the document outline and lets the user collapse/expand blocks.
 
     The data represented by the panel come from the text block user state and
@@ -356,7 +357,7 @@ class FoldingPanel(Panel):
         rect = QtCore.QRect(0, top, self.sizeHint().width(),
                             self.sizeHint().height())
         if self._native:
-            if os.environ['QT_API'].lower() != 'pyqt5':
+            if os.environ['QT_API'].lower() not in PYQT5_API:
                 opt = QtGui.QStyleOptionViewItemV2()
             else:
                 opt = QtWidgets.QStyleOptionViewItem()

--- a/pyqode/core/widgets/prompt_line_edit.py
+++ b/pyqode/core/widgets/prompt_line_edit.py
@@ -4,9 +4,14 @@ This module contains the PromptLineEdit widget implementation.
 """
 import os
 from pyqode.qt import QtWidgets, QtCore, QtGui
+from pyqode.qt import QT_API
+from pyqode.qt import PYQT5_API
+from pyqode.qt import PYQT4_API
+from pyqode.qt import PYSIDE_API
 
 
 class PromptLineEdit(QtWidgets.QLineEdit):
+
     """
     Extends QLineEdit to show a prompt text and a clear icon
     """
@@ -52,16 +57,20 @@ class PromptLineEdit(QtWidgets.QLineEdit):
     def paintEvent(self, event):
         super(PromptLineEdit, self).paintEvent(event)
 
+        qt_api = os.environ['QT_API'].lower()
         if self._prompt_text and not self.text() and self.isEnabled():
-            if os.environ['QT_API'].lower() == 'pyqt4':
+            if qt_api in PYQT4_API:
                 from PyQt4.QtGui import QStyleOptionFrameV3
                 option = QStyleOptionFrameV3()
-            elif os.environ['QT_API'].lower() == 'pyside':
+            elif qt_api in PYSIDE_API:
                 from PySide.QtGui import QStyleOptionFrameV3
                 option = QStyleOptionFrameV3()
-            else:
+            elif qt_api in PYQT5_API:
                 from PyQt5.QtWidgets import QStyleOptionFrame
                 option = QStyleOptionFrame()
+            else:
+                msg = 'Qt bindings "%s" is not supported' % qt_api
+                raise PythonQtError(msg)
 
             self.initStyleOption(option)
 


### PR DESCRIPTION
For example, in pyqode name for PyQt4 api is "pyqt4", whereas IPython api name is "pyqt"
This patch support both names. Multiple name support is also available for PySide and PyQt5.