### PR TITLE
Add a new OutputWindow that supports ANSI Escape Codes

### DIFF
--- a/examples/widgets/interactive_process.py
+++ b/examples/widgets/interactive_process.py
@@ -5,11 +5,15 @@ InteractiveConsole widget.
 import sys
 print('running an interactive process')
 
-if sys.version_info[0] == 2:
-    value1 = raw_input('Enter value1: ')
-    value2 = raw_input('Enter value2: ')
-else:
-    value1 = input('Enter value1: ')
-    value2 = input('Enter value2: ')
-print("Result: %d" % (int(value1) + int(value2)))
 
+if sys.version_info[0] == 2:
+    input_fct = raw_input
+else:
+    input_fct = input
+
+value1 = input_fct('Enter value1: ')
+value2 = input_fct('Enter value2: ')
+value3 = input_fct('Enter value3: ')
+value4 = input_fct('Enter value4: ')
+
+print('You entered: %r - %r - %r - %r' % (value1, value2, value3, value4))

--- a/examples/widgets/output_window.py
+++ b/examples/widgets/output_window.py
@@ -1,0 +1,16 @@
+"""
+This example show how to use the OutputWindow widget.
+"""
+import sys
+from pyqode.qt import QtWidgets
+
+from pyqode.core.widgets import OutputWindow
+
+
+if __name__ == '__main__':
+    app = QtWidgets.QApplication([])
+    win = OutputWindow()
+    win.resize(800, 600)
+    win.start_process(sys.executable, ['interactive_process.py'])
+    win.show()
+    app.exec_()

--- a/examples/widgets/terminal.py
+++ b/examples/widgets/terminal.py
@@ -1,0 +1,14 @@
+"""
+This example show you how to use the Terminal widget
+"""
+from pyqode.qt import QtWidgets
+
+from pyqode.core.widgets import Terminal
+
+
+if __name__ == '__main__':
+    app = QtWidgets.QApplication([])
+    win = Terminal()
+    win.resize(800, 600)
+    win.show()
+    app.exec_()

--- a/pyqode/core/api/client.py
+++ b/pyqode/core/api/client.py
@@ -393,9 +393,11 @@ class BackendProcess(QtCore.QProcess):
 
     def _on_process_stderr_ready(self):
         """ Logs process output (stderr) """
-        if not self:
+        try:
+            o = self.readAllStandardError()
+        except (TypeError, RuntimeError):
+            # widget already deleted
             return
-        o = self.readAllStandardError()
         try:
             output = bytes(o).decode(self._encoding)
         except TypeError:

--- a/pyqode/core/api/code_edit.py
+++ b/pyqode/core/api/code_edit.py
@@ -914,6 +914,10 @@ class CodeEdit(QtWidgets.QPlainTextEdit):
         super(CodeEdit, self).resizeEvent(e)
         self.panels.resize()
 
+    def closeEvent(self, e):
+        self.close()
+        super(CodeEdit, self).closeEvent(e)
+
     def paintEvent(self, e):
         """
         Overrides paint event to update the list of visible blocks and emit

--- a/pyqode/core/widgets/__init__.py
+++ b/pyqode/core/widgets/__init__.py
@@ -21,7 +21,7 @@ from pyqode.core.widgets.encodings import (EncodingsComboBox, EncodingsMenu,
                                            EncodingsContextMenu)
 from pyqode.core.widgets.errors_table import ErrorsTable
 from pyqode.core.widgets.file_icons_provider import FileIconProvider
-from pyqode.core.widgets.interactive import InteractiveConsole
+from pyqode.core.widgets.interactive import InteractiveConsole  # Deprecated
 from pyqode.core.widgets.menu_recents import MenuRecentFiles
 from pyqode.core.widgets.menu_recents import RecentFilesManager
 from pyqode.core.widgets.preview import HtmlPreviewWidget
@@ -34,6 +34,9 @@ from pyqode.core.widgets.splittable_tab_widget import (
 from pyqode.core.widgets.filesystem_treeview import FileSystemTreeView
 from pyqode.core.widgets.filesystem_treeview import FileSystemContextMenu
 from pyqode.core.widgets.filesystem_treeview import FileSystemHelper
+from pyqode.core.widgets.output_window import OutputWindow
+from pyqode.core.widgets.terminal import Terminal
+
 
 __all__ = [
     'ErrorsTable',
@@ -55,5 +58,7 @@ __all__ = [
     'SplittableTabWidget',
     'SplittableCodeEditTabWidget',
     'TabBar',
-    'HtmlPreviewWidget'
+    'HtmlPreviewWidget',
+    'OutputWindow',
+    'Terminal'
 ]

--- a/pyqode/core/widgets/interactive.py
+++ b/pyqode/core/widgets/interactive.py
@@ -36,6 +36,9 @@ class InteractiveConsole(QTextEdit):
           process started, process finished)
         - stderr_color: color of the process stderr
 
+    .. deprecated: Since v2.10.0, this widget is deprecated, you should use
+        :class:`pyqode.core.widgets.OutputWindow` instead.
+
     """
     #: Signal emitted when the process has finished.
     process_finished = Signal(int)

--- a/pyqode/core/widgets/output_window.py
+++ b/pyqode/core/widgets/output_window.py
@@ -1,0 +1,1175 @@
+"""
+This module contains the output window widget that can be used to visually run a child process in a PyQt application.
+
+The widget supports most ANSI Escape Sequences (colors, cursor positioning,...) and can be used to create a rudimentary
+terminal emulator (such a widget is available in the terminal module).
+"""
+import logging
+import os
+import re
+import sys
+
+from collections import namedtuple
+
+from pyqode.core.api import CodeEdit, SyntaxHighlighter
+from pyqode.core.api.client import PROCESS_ERROR_STRING
+from pyqode.core.backend import server
+from pyqode.qt import QtWidgets, QtGui, QtCore
+from pyqode.qt.QtGui import QColor
+from pyqode.qt.QtWidgets import qApp
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# Widget
+# ----------------------------------------------------------------------------------------------------------------------
+class OutputWindow(CodeEdit):
+    """
+    Widget that runs a child process and print its output in a text area.
+
+    This widget can be used to show the output of a process in a Qt application (i.e. the run output of an IDE) or
+    it could be used to implement a terminal emulator. While the parser supports most common Ansi Escape Codes, it
+    does not aim to support all VT100 features.
+
+    User inputs are handled by an InputHandler, there are two types of input handlers:
+        - ImmediateInputHandler: forward ansi code of each key strokes directly to the child process's stdin. Use this
+          for an interactive process such as bash or python.
+        - BufferedInputHandler: bufferize user inputs until user pressed enter. Use this for any other kind of process.
+
+    Usage:
+
+        - create an OutputWindow instance (you can specify a color scheme and an input handler).
+        - call start_process to actually start your child process.
+    """
+    #
+    # Public API
+    #
+    #: Define the color_scheme of the output window.
+    ColorScheme = namedtuple('ColorScheme', 'background foreground error custom red green yellow blue magenta cyan')
+
+    #: Default theme using QPalette colors, must be initialised by a call to ``_init_default_scheme``
+    DefaultColorScheme = None
+    #: Linux color scheme (black background with ANSI colors)
+    LinuxColorScheme = None
+    #: Tango theme (black background with pastel colors).
+    TangoColorScheme = None
+    #: The famous Solarized dark theme.
+    SolarizedColorScheme = None
+
+    #: Signal emitted when the user pressed on a file link.
+    #: Client code should open the requested file in the editor.
+    #: Parameters:
+    #:    - path (str)
+    #:    - line number (int, 0 based)
+    open_file_requested = QtCore.Signal(str, int)
+
+    @property
+    def color_scheme(self):
+        return self._formatter.theme
+
+    @color_scheme.setter
+    def color_scheme(self, scheme):
+        self._formatter.color_scheme = scheme
+        self.background = scheme.background
+        self.foreground = scheme.foreground
+        self._reset_stylesheet()
+
+    @property
+    def input_handler(self):
+        return self._input_handler
+
+    @input_handler.setter
+    def input_handler(self, handler):
+        self._input_handler = handler
+        self._input_handler.edit = self
+        self._input_handler.process = self._process
+
+    def __init__(self, parent=None, color_scheme=None, formatter=None, input_handler=None, backend=server.__file__,
+                 link_regex=re.compile(r'File "(?P<url>(/|[a-zA-Z]:\\).*)"(, line (?P<line>\d*))?')):
+        """
+        :param parent: parent widget, if any
+        :param color_scheme: color scheme to use
+        :param formatter: The formatter to use to draw the process output. Use our builtin formatter by default.
+        :param input_handler: the user input handler, buffered by default.
+        :param backend: backend script used for searching in the process output.
+        :param link_regex: Regex used to match file links, default regex was made to match file path of python
+            tracebacks. You can specify another regex if needed, the only requirements is that the regex must have
+            two named capture groups: 'url' and 'line'
+        """
+        super(OutputWindow, self).__init__(parent)
+        if formatter is None:
+            formatter = OutputFormatter(self, color_scheme=color_scheme)
+        if input_handler is None:
+            input_handler = BufferedInputHandler()
+        self.link_regex = link_regex
+        self._link_match = None
+        self._formatter = formatter
+        self._init_code_edit(backend)
+        self._process = QtCore.QProcess()
+        self._process.readyReadStandardOutput.connect(self._read_stdout)
+        self._process.readyReadStandardError.connect(self._read_stderr)
+        self._process.error.connect(self._on_process_error)
+        self._process.finished.connect(self._on_process_finished)
+        self._input_handler = input_handler
+        self._input_handler.edit = self
+        self._input_handler.process = self._process
+        self._last_hovered_block = None
+        self.flg_use_pty = False
+
+    def start_process(self, program, arguments=None, working_dir=None, print_command=True,
+                      use_pseudo_terminal=False, env=None):
+        """
+        Starts the child process.
+
+        :param program: program to start
+        :param arguments: list of program arguments
+        :param working_dir: working directory of the child process
+        :param print_command: True to print the full command (pgm + arguments) as the first line
+            of the output window
+        :param use_pseudo_terminal: True to use a pseudo terminal on Unix (pty), False to avoid
+            using a pty wrapper. When using a pty wrapper, both stdout and stderr are merged together.
+        :param environ: environment variables to set on the child process. If None, os.environ will be used.
+        """
+        # clear previous output
+        self.clear()
+        if arguments is None:
+            arguments = []
+        if sys.platform != 'win32' and use_pseudo_terminal:
+            pgm = sys.executable
+            args = [__file__, program] + arguments
+            self.flg_use_pty = use_pseudo_terminal
+        else:
+            pgm = program
+            args = arguments
+            self.flg_use_pty = False  # pty not available on windows
+
+        self._process.setProcessEnvironment(self._setup_process_environment(env))
+
+        if working_dir:
+            self._process.setWorkingDirectory(working_dir)
+
+        if print_command:
+            self._formatter.append_message('\x1b[0m%s %s\n' % (program, ' '.join(arguments)),
+                                           output_format=OutputFormat.CustomFormat)
+        self._process.start(pgm, args)
+
+    def terminate_process(self):
+        """
+        Terminates the child process.
+        """
+        self._process.terminate()
+        if not self._process.waitForFinished(100):
+            self._process.kill()
+
+    def paste(self):
+        """
+        Paste the content of the clipboard to the child process'stdtin.
+        """
+        self._process.write(QtWidgets.qApp.clipboard().text().encode())
+
+    @staticmethod
+    def create_color_scheme(background=None, foreground=None, error=None, custom=None, red=None,
+                            green=None, yellow=None, blue=None, magenta=None, cyan=None):
+        """
+        Utility function that creates a color scheme instance, with default values.
+
+        The default colors are chosen based on the current palette.
+
+        :param background: background color
+        :param foreground: foreground color
+        :param error: color of error messages (stderr)
+        :param custom: color of custom messages (e.g. to print the full command or the process exit code)
+        :param red: value of the red ANSI color
+        :param green: value of the green ANSI color
+        :param yellow: value of the yellow ANSI color
+        :param blue: value of the blue ANSI color
+        :param magenta: value of the magenta ANSI color
+        :param cyan: value of the cyan ANSI color
+        :return: A ColorScheme instance.
+        """
+        if background is None:
+            background = qApp.palette().base().color()
+        if foreground is None:
+            foreground = qApp.palette().text().color()
+        is_light = background.lightness() >= 128
+        if error is None:
+            if is_light:
+                error = QColor('dark red')
+            else:
+                error = QColor('#FF5555')
+        if red is None:
+            red = QColor(error)
+        if green is None:
+            if is_light:
+                green = QColor('dark green')
+            else:
+                green = QColor('#55FF55')
+        if yellow is None:
+            if is_light:
+                yellow = QColor('#aaaa00')
+            else:
+                yellow = QColor('#FFFF55')
+        if blue is None:
+            if is_light:
+                blue = QColor('dark blue')
+            else:
+                blue = QColor('#5555FF')
+        if magenta is None:
+            if is_light:
+                magenta = QColor('dark magenta')
+            else:
+                magenta = QColor('#FF55FF')
+        if cyan is None:
+            if is_light:
+                cyan = QColor('dark cyan')
+            else:
+                cyan = QColor('#55FFFF')
+        if custom is None:
+            custom = QColor('orange')
+        return OutputWindow.ColorScheme(background, foreground, error, custom,
+                                        red, green, yellow, blue, magenta, cyan)
+
+    #
+    # Overriden Qt Methods
+    #
+    def eventFilter(self, *args):
+        return False
+
+    def closeEvent(self, event):
+        """
+        Terminates the child process on close.
+        """
+        super(OutputWindow, self).closeEvent(event)
+        self.terminate_process()
+        self.backend.stop()
+
+    def keyPressEvent(self, event):
+        if self._process.state() != self._process.Running:
+            return
+        if self.input_handler.key_press_event(event):
+            super(OutputWindow, self).keyPressEvent(event)
+            self._formatter._last_cursor_pos = self.textCursor().position()
+
+    def mouseMoveEvent(self, event):
+        c = self.cursorForPosition(event.pos())
+        block = c.block()
+        if block != self._last_hovered_block:
+            match = self.link_regex.search(block.text())
+            if match:
+                self._link_match = match
+                self.viewport().setCursor(QtCore.Qt.PointingHandCursor)
+            else:
+                self._link_match = None
+                self.viewport().setCursor(QtCore.Qt.IBeamCursor)
+            self._last_hovered_block = block
+        super(OutputWindow, self).mouseMoveEvent(event)
+
+    def mousePressEvent(self, event):
+        super(OutputWindow, self).mousePressEvent(event)
+        if self._link_match:
+            path = self._link_match.group('url')
+            line = self._link_match.group('line')
+            if line is not None:
+                line = int(line) - 1
+            else:
+                line = 0
+            self.open_file_requested.emit(path, line)
+
+    #
+    # Utility methods
+    #
+    def _init_code_edit(self, backend):
+        from pyqode.core import panels, modes
+
+        self.modes.append(_LinkHighlighter(self))
+        self.background = self._formatter.color_scheme.background
+        self.foreground = self._formatter.color_scheme.foreground
+        self._reset_stylesheet()
+        self.setCenterOnScroll(False)
+        self.setMouseTracking(True)
+        search_panel = panels.SearchAndReplacePanel()
+        self.panels.append(search_panel, search_panel.Position.TOP)
+        self.action_copy.setShortcut('Ctrl+Shift+C')
+        self.action_paste.setShortcut('Ctrl+Shift+V')
+        self.remove_action(self.action_undo, sub_menu=None)
+        self.remove_action(self.action_redo, sub_menu=None)
+        self.remove_action(self.action_cut, sub_menu=None)
+        self.remove_action(self.action_duplicate_line, sub_menu=None)
+        self.remove_action(self.action_indent)
+        self.remove_action(self.action_un_indent)
+        self.remove_action(self.action_goto_line)
+        self.remove_action(search_panel.menu.menuAction())
+        self.remove_menu(self._sub_menus['Advanced'])
+        self.add_action(search_panel.actionSearch, sub_menu=None)
+        self.modes.append(modes.ZoomMode())
+        self.backend.start(backend)
+
+    def _setup_process_environment(self, env):
+        environ = self._process.processEnvironment()
+        if env is None:
+            env = os.environ
+        if 'PYTHONUNBUFFERED' not in env:
+            env['PYTHONUNBUFFERED'] = '1'
+        if 'QT_LOGGING_TO_CONSOLE' not in env:
+            env['QT_LOGGING_TO_CONSOLE'] = '1'
+        for k, v in env.items():
+            environ.insert(k, v)
+        if sys.platform != 'win32':
+            environ.insert('TERM', 'xterm')
+        return environ
+
+    def _on_process_error(self, error):
+        if self is None:
+            return
+        err = PROCESS_ERROR_STRING[error]
+        self._formatter.append_message(err + '\r\n', output_format=OutputFormat.ErrorMessageFormat)
+
+    def _on_process_finished(self):
+        exit_code = self._process.exitCode()
+        if self._process.exitStatus() != self._process.NormalExit:
+            exit_code = 139
+        self._formatter.append_message('\x1b[0m\nProcess finished with exit code %d' % exit_code,
+                                       output_format=OutputFormat.CustomFormat)
+        self.setReadOnly(True)
+
+    def _read_stdout(self):
+        output = self._process.readAllStandardOutput().data().decode()
+        if self._formatter:
+            self._formatter.append_message(output, output_format=OutputFormat.NormalMessageFormat)
+        else:
+            self.insertPlainText(output)
+
+    def _read_stderr(self):
+        output = self._process.readAllStandardError().data().decode()
+        if self._formatter:
+            self._formatter.append_message(output, output_format=OutputFormat.ErrorMessageFormat)
+        else:
+            self.insertPlainText(output)
+
+
+class _LinkHighlighter(SyntaxHighlighter):
+    """
+    Highlights links using OutputWindow.link_regex.
+    """
+    def highlight_block(self, text, block):
+        match = self.editor.link_regex.search(text)
+        if match:
+            start, end = match.span('url')
+            fmt = QtGui.QTextCharFormat()
+            fmt.setForeground(QtWidgets.qApp.palette().highlight().color())
+            fmt.setUnderlineStyle(fmt.SingleUnderline)
+            self.setFormat(start, end - start, fmt)
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# Parser
+# ----------------------------------------------------------------------------------------------------------------------
+#: Represents a formatted text: a string + a QtGui.QTextCharFormat
+FormattedText = namedtuple('FormattedText', 'txt fmt')
+#: Generic structure for representing a terminal operation (draw, move cursor,...).
+Operation = namedtuple('Operation', 'command data')
+
+
+class AnsiEscapeCodeParser(object):
+    """
+    The AnsiEscapeCodeParser class parses text and extracts ANSI escape codes from it.
+
+    In order to preserve color information across text segments, an instance of this class
+    must be stored for the lifetime of a stream.
+    Also, one instance of this class should not handle multiple streams (at least not
+    at the same time).
+
+    Its main function is parse_text(), which accepts text and default QTextCharFormat.
+
+    This function is designed to parse text and split colored text to smaller strings,
+    with their appropriate formatting information set inside QTextCharFormat.
+
+    Compared to the QtCreator implementation, we added limited support for terminal
+    emulation (changing cursor position, erasing display/line,...).
+
+    Usage:
+        - Create new instance of AnsiEscapeCodeParser for a stream.
+        - To add new text, call parse_text() with the text and a default QTextCharFormat.
+          The result of this function is a list of Operation with their associated data.
+    """
+
+    _ResetFormat = 0
+    _BoldText = 1
+    _ItalicText = 3
+    _UnderlinedText = 4
+    _NotBold = 21
+    _NotItalicNotFraktur = 23
+    _NotUnderlined = 24
+    _Negative = 7
+    _Positive = 27
+    _TextColorStart = 30
+    _TextColorEnd = 37
+    _RgbTextColor = 38
+    _DefaultTextColor = 39
+    _BackgroundColorStart = 40
+    _BackgroundColorEnd = 47
+    _RgbBackgroundColor = 48
+    _DefaultBackgroundColor = 49
+    _Dim = 2
+
+    _escape = "\x1b["
+    _escape_alts = ["\x1b(", "\x1b)", '\x1b=', '\x1b]', '\x08', '\x07']
+    _escape_len = len(_escape)
+    _semicolon = ';'
+    _color_terminator = 'm'
+
+    _supported_commands = re.compile(r'^(?P<n>\d*;?\d*)(?P<cmd>[ABCDEFGHJKfP]{1})')
+    _unsupported_command = re.compile(r'^(\?\d+h)|^(\??\d+l)|^(\d+d)|^(\d+X)|^(\([AB01])|'
+                                      r'^(\)[AB01])|^(\d*;?\d*r)|^(=)|^(>)|^(\d;.*\x07)')
+
+    _commands = {
+        'A': 'cursor_up',
+        'B': 'cursor_down',
+        'C': 'cursor_forward',
+        'D': 'cursor_back',
+        'E': 'cursor_next_line',
+        'F': 'cursor_previous_lined',
+        'G': 'cursor_horizontal_absolute',
+        'H': 'cursor_position',
+        'J': 'erase_display',
+        'K': 'erase_in_line',
+        'f': 'cursor_position',  # same as H
+        'P': 'delete_chars'
+    }
+
+    DIM_FACTOR = 120
+
+    def __init__(self):
+        fmt = QtGui.QTextCharFormat()
+        fmt.setForeground(QtWidgets.qApp.palette().text().color())
+        fmt.setBackground(QtWidgets.qApp.palette().base().color())
+        FormattedText.__new__.__defaults__ = '', fmt
+        self._prev_fmt_closed = True
+        self._prev_fmt = fmt
+        self._pending_text = ''
+        self.color_scheme = None
+
+    def parse_text(self, formatted_text):
+        """
+        Retursn a list of operations (draw, cup, ed,...).
+
+        Each operation consist of a command and its associated data.
+
+        :param formatted_text: text to parse with the default char format to apply.
+        :return: list of Operation
+        """
+        assert isinstance(formatted_text, FormattedText)
+        ret_val = []
+        fmt = formatted_text.fmt if self._prev_fmt_closed else self._prev_fmt
+        fmt = QtGui.QTextCharFormat(fmt)
+        if not self._pending_text:
+            stripped_text = formatted_text.txt
+        else:
+            stripped_text = self._pending_text + formatted_text.txt
+            self._pending_text = ''
+        while stripped_text:
+            try:
+                escape_pos = stripped_text.index(self._escape[0])
+            except ValueError:
+                ret_val.append(Operation('draw', FormattedText(stripped_text, fmt)))
+                break
+            else:
+                if escape_pos != 0:
+                    ret_val.append(Operation('draw', FormattedText(stripped_text[:escape_pos], fmt)))
+                    stripped_text = stripped_text[escape_pos:]
+                    fmt = QtGui.QTextCharFormat(fmt)
+            assert stripped_text[0] == self._escape[0]
+            while stripped_text and stripped_text[0] == self._escape[0]:
+                if self._escape.startswith(stripped_text):
+                    # control sequence not complete
+                    self._pending_text += stripped_text
+                    stripped_text = ''
+                    break
+                if not stripped_text.startswith(self._escape):
+                    # check vt100 escape sequences
+                    ctrl_seq = False
+                    for alt_seq in self._escape_alts:
+                        if stripped_text.startswith(alt_seq):
+                            ctrl_seq = True
+                            break
+                    if not ctrl_seq:
+                        # not a control sequence
+                        self._pending_text = ''
+                        ret_val.append(Operation('draw', FormattedText(stripped_text[:1], fmt)))
+                        fmt = QtGui.QTextCharFormat(fmt)
+                        stripped_text = stripped_text[1:]
+                        continue
+                self._pending_text += _mid(stripped_text, 0, self._escape_len)
+                stripped_text = stripped_text[self._escape_len:]
+
+                # Non draw related command (cursor/erase)
+                if self._pending_text in [self._escape] + self._escape_alts:
+                    m = self._supported_commands.match(stripped_text)
+                    if m and self._pending_text == self._escape:
+                        _, e = m.span()
+                        n = m.group('n')
+                        cmd = m.group('cmd')
+                        if not n:
+                            n = 0
+                        ret_val.append(Operation(self._commands[cmd], n))
+                        self._pending_text = ''
+                        stripped_text = stripped_text[e:]
+                        continue
+                    else:
+                        m = self._unsupported_command.match(stripped_text)
+                        if m:
+                            self._pending_text = ''
+                            stripped_text = stripped_text[m.span()[1]:]
+                            continue
+                        elif self._pending_text in ['\x1b=', '\x1b>']:
+                            self._pending_text = ''
+                            continue
+
+                # Handle Select Graphic Rendition commands
+                # get the number
+                str_nbr = ''
+                numbers = []
+                while stripped_text:
+                    if stripped_text[0].isdigit():
+                        str_nbr += stripped_text[0]
+                    else:
+                        if str_nbr:
+                            numbers.append(str_nbr)
+                        if not str_nbr or stripped_text[0] != self._semicolon:
+                            break
+                        str_nbr = ''
+                    self._pending_text += _mid(stripped_text, 0, 1)
+                    stripped_text = stripped_text[1:]
+
+                if not stripped_text:
+                    break
+
+                # remove terminating char
+                if not stripped_text.startswith(self._color_terminator):
+                    # _logger().warn('removing %s', repr(self._pending_text + stripped_text[0]))
+                    self._pending_text = ''
+                    stripped_text = stripped_text[1:]
+                    break
+
+                # got consistent control sequence, ok to clear pending text
+                self._pending_text = ''
+                stripped_text = stripped_text[1:]
+
+                if not numbers:
+                    fmt = QtGui.QTextCharFormat(formatted_text.fmt)
+                    self.end_format_scope()
+
+                i_offset = 0
+                n = len(numbers)
+                for i in range(n):
+                    i += i_offset
+                    code = int(numbers[i])
+
+                    if self._TextColorStart <= code <= self._TextColorEnd:
+                        fmt.setForeground(_ansi_color(code - self._TextColorStart, self.color_scheme))
+                        self._set_format_scope(fmt)
+                    elif self._BackgroundColorStart <= code <= self._BackgroundColorEnd:
+                        fmt.setBackground(_ansi_color(code - self._BackgroundColorStart, self.color_scheme))
+                        self._set_format_scope(fmt)
+                    else:
+                        if code == self._ResetFormat:
+                            fmt = QtGui.QTextCharFormat(formatted_text.fmt)
+                            self.end_format_scope()
+                        elif code == self._BoldText:
+                            fmt.setFontWeight(QtGui.QFont.Bold)
+                            self._set_format_scope(fmt)
+                        elif code == self._NotBold:
+                            fmt.setFontWeight(QtGui.QFont.Normal)
+                            self._set_format_scope(fmt)
+                        elif code == self._ItalicText:
+                            fmt.setFontItalic(True)
+                            self._set_format_scope(fmt)
+                        elif code == self._NotItalicNotFraktur:
+                            fmt.setFontItalic(False)
+                            self._set_format_scope(fmt)
+                        elif code == self._UnderlinedText:
+                            fmt.setUnderlineStyle(fmt.SingleUnderline)
+                            fmt.setUnderlineColor(fmt.foreground().color())
+                            self._set_format_scope(fmt)
+                        elif code == self._NotUnderlined:
+                            fmt.setUnderlineStyle(fmt.NoUnderline)
+                            self._set_format_scope(fmt)
+                        elif code == self._DefaultTextColor:
+                            fmt.setForeground(formatted_text.fmt.foreground())
+                            self._set_format_scope(fmt)
+                        elif code == self._DefaultBackgroundColor:
+                            fmt.setBackground(formatted_text.fmt.background())
+                            self._set_format_scope(fmt)
+                        elif code == self._Dim:
+                            fmt = QtGui.QTextCharFormat(fmt)
+                            fmt.setForeground(fmt.foreground().color().darker(self.DIM_FACTOR))
+                        elif code == self._Negative:
+                            normal_fmt = fmt
+                            fmt = QtGui.QTextCharFormat(fmt)
+                            fmt.setForeground(normal_fmt.background())
+                            fmt.setBackground(normal_fmt.foreground())
+                        elif code == self._Positive:
+                            fmt = QtGui.QTextCharFormat(formatted_text.fmt)
+                        elif code in [self._RgbBackgroundColor, self._RgbTextColor]:
+                            # See http://en.wikipedia.org/wiki/ANSI_escape_code#Colors
+                            i += 1
+                            if i == n:
+                                break
+                            next_code = int(numbers[i])
+                            if next_code == 2:
+                                # RGB set with format: 38;2;<r>;<g>;<b>
+                                if i + 3 < n:
+                                    method = fmt.setForeground if code == self._RgbTextColor else fmt.setBackground
+                                    method(QtGui.QColor(int(numbers[i + 1]), int(numbers[i + 2]), int(numbers[i + 3])))
+                                    self._set_format_scope(fmt)
+                                i_offset = 3
+                            elif next_code == 5:
+                                # 256 color mode with format: 38;5;<i>
+                                index = int(numbers[i + 1])
+                                if index < 8:
+                                    # The first 8 colors are standard low-intensity ANSI colors.
+                                    color = _ansi_color(index, self.color_scheme)
+                                elif index < 16:
+                                    # The next 8 colors are standard high-intensity ANSI colors.
+                                    color = _ansi_color(index - 8, self.color_scheme).lighter(150)
+                                elif index < 232:
+                                    # The next 216 colors are a 6x6x6 RGB cube.
+                                    o = index - 16
+                                    color = QtGui.QColor((o / 36) * 51, ((o / 6) % 6) * 51, (o % 6) * 51)
+                                else:
+                                    # The last 24 colors are a greyscale gradient.
+                                    grey = (index - 232) * 11
+                                    color = QtGui.QColor(grey, grey, grey)
+
+                                if code == self._RgbTextColor:
+                                    fmt.setForeground(color)
+                                else:
+                                    fmt.setBackground(color)
+
+                                self._set_format_scope(fmt)
+                        else:
+                            _logger().warn('unsupported SGR code: %r', code)
+        return ret_val
+
+    def end_format_scope(self):
+        self._prev_fmt_closed = True
+
+    def _set_format_scope(self, fmt):
+        self._prev_fmt = QtGui.QTextCharFormat(fmt)
+        self._prev_fmt_closed = False
+
+
+def _mid(string, start, end=None):
+    if end is None:
+        end = len(string)
+    return string[start:start + end]
+
+
+def _ansi_color(code, theme):
+    red = 170 if code & 1 else 0
+    green = 170 if code & 2 else 0
+    blue = 170 if code & 4 else 0
+    color = QtGui.QColor(red, green, blue)
+    if theme is not None:
+        mappings = {
+            '#aa0000': theme.red,
+            '#00aa00': theme.green,
+            '#aaaa00': theme.yellow,
+            '#0000aa': theme.blue,
+            '#aa00aa': theme.magenta,
+            '#00aaaa': theme.cyan
+        }
+        try:
+            return mappings[color.name()]
+        except KeyError:
+            pass
+    return color
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# Input handlers
+# ----------------------------------------------------------------------------------------------------------------------
+class InputHandler(object):
+    def __init__(self):
+        # references set by the outout window instance that owns the handler.
+        self.edit = None
+        self.process = None
+
+
+class ImmediateInputHandler(InputHandler):
+    def key_press_event(self, event):
+        """
+        Directly writes the ascii code of the key to the process' stdin.
+
+        :retuns: False to prevent the event from being propagated to the parent widget.
+        """
+        if event.key() == QtCore.Qt.Key_Return:
+            cursor = self.edit.textCursor()
+            cursor.movePosition(cursor.EndOfBlock)
+            self.edit.setTextCursor(cursor)
+        code = _qkey_to_ascii(event)
+        if code is not None:
+            self.process.writeData(code)
+        return False
+
+
+def _qkey_to_ascii(event):
+    """
+    (Try to) convert the Qt key event to the corresponding ASCII sequence for
+    the terminal. This works fine for standard alphanumerical characters, but
+    most other characters require terminal specific control sequences.
+    The conversion below works for TERM="linux' terminals.
+    """
+    if event.modifiers() == QtCore.Qt.ControlModifier:
+        if event.key() == QtCore.Qt.Key_P:
+            return b'\x10'
+        elif event.key() == QtCore.Qt.Key_N:
+            return b'\x0E'
+        elif event.key() == QtCore.Qt.Key_C:
+            return b'\x03'
+        elif event.key() == QtCore.Qt.Key_L:
+            return b'clear\n'
+        elif event.key() == QtCore.Qt.Key_B:
+            return b'\x02'
+        elif event.key() == QtCore.Qt.Key_F:
+            return b'\x06'
+        elif event.key() == QtCore.Qt.Key_D:
+            return b'\x04'
+        elif event.key() == QtCore.Qt.Key_O:
+            return b'\x0F'
+        elif event.key() == QtCore.Qt.Key_V:
+            return QtWidgets.qApp.clipboard().text().encode('utf-8')
+        else:
+            return None
+    else:
+        if event.key() == QtCore.Qt.Key_Return:
+            return '\n'.encode('utf-8')
+        elif event.key() == QtCore.Qt.Key_Enter:
+            return '\n'.encode('utf-8')
+        elif event.key() == QtCore.Qt.Key_Tab:
+            return '\t'.encode('utf-8')
+        elif event.key() == QtCore.Qt.Key_Backspace:
+            return b'\x08'
+        elif event.key() == QtCore.Qt.Key_Delete:
+            return b'\x06\x08'
+        elif event.key() == QtCore.Qt.Key_Enter:
+            return '\n'.encode('utf-8')
+        elif event.key() == QtCore.Qt.Key_Home:
+            return b'\x1b[H'
+        elif event.key() == QtCore.Qt.Key_End:
+            return b'\x1b[F'
+        elif event.key() == QtCore.Qt.Key_Left:
+            return b'\x02'
+        elif event.key() == QtCore.Qt.Key_Up:
+            return b'\x10'
+        elif event.key() == QtCore.Qt.Key_Right:
+            return b'\x06'
+        elif event.key() == QtCore.Qt.Key_Down:
+            return b'\x0E'
+        elif event.key() == QtCore.Qt.Key_PageUp:
+            return b'\x49'
+        elif event.key() == QtCore.Qt.Key_PageDown:
+            return b'\x51'
+        elif event.key() == QtCore.Qt.Key_F1:
+            return b'\x1b\x31'
+        elif event.key() == QtCore.Qt.Key_F2:
+            return b'\x1b\x32'
+        elif event.key() == QtCore.Qt.Key_F3:
+            return b'\x00\x3b'
+        elif event.key() == QtCore.Qt.Key_F4:
+            return b'\x1b\x34'
+        elif event.key() == QtCore.Qt.Key_F5:
+            return b'\x1b\x35'
+        elif event.key() == QtCore.Qt.Key_F6:
+            return b'\x1b\x36'
+        elif event.key() == QtCore.Qt.Key_F7:
+            return b'\x1b\x37'
+        elif event.key() == QtCore.Qt.Key_F8:
+            return b'\x1b\x38'
+        elif event.key() == QtCore.Qt.Key_F9:
+            return b'\x1b\x39'
+        elif event.key() == QtCore.Qt.Key_F10:
+            return b'\x1b\x30'
+        elif event.key() == QtCore.Qt.Key_F11:
+            return b'\x45'
+        elif event.key() == QtCore.Qt.Key_F12:
+            return b'\x46'
+        elif event.text() in ('abcdefghijklmnopqrstuvwxyz'
+                              'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+                              '[],=-.;/`&^~*@|#(){}$><%+?"_!'
+                              "'\\ :"):
+            return event.text().encode('utf8')
+        else:
+            return None
+
+
+class BufferedInputHandler(InputHandler):
+    def __init__(self):
+        super(BufferedInputHandler, self).__init__()
+        self._input_buffer = ''
+
+    def key_press_event(self, event):
+        """
+        Manages our own buffer and send it to the subprocess when user pressed RETURN.
+        """
+        ctrl = int(event.modifiers() & QtCore.Qt.ControlModifier) != 0
+        delete = event.key() in [QtCore.Qt.Key_Backspace, QtCore.Qt.Key_Delete]
+        ignore = False
+        if delete and not self._input_buffer:
+            return False
+        if ctrl:
+            if event.key() == QtCore.Qt.Key_V:
+                # Paste to usr buffer
+                text = QtWidgets.qApp.clipboard().text()
+                self._input_buffer += text
+                self.edit.insertPlainText(text)
+                return False
+            elif event.key() == QtCore.Qt.Key_L:
+                self.edit.clear()
+                if sys.platform == 'win32':
+                    self.process.write(b'\r')
+                self.process.write(b'\n')
+                return False
+        if event.key() in [QtCore.Qt.Key_Return, QtCore.Qt.Key_Enter]:
+            # send the user input to the child process
+            if self.edit.flg_use_pty:
+                # remove user buffer from text edit, the content of the buffer will be
+                # drawn as soon as we write it to the process stdin
+                tc = self.edit.textCursor()
+                for _ in self._input_buffer:
+                    tc.deletePreviousChar()
+                self.edit.setTextCursor(tc)
+            if sys.platform == 'win32':
+                self._input_buffer += "\r"
+            self._input_buffer += "\n"
+            self.process.write(self._input_buffer.encode())
+            self._input_buffer = ""
+            if self.edit.flg_use_pty:
+                ignore = True
+        else:
+            if not delete and len(event.text()):
+                txt = event.text()
+                self._input_buffer += txt
+            elif delete:
+                self._input_buffer = self._input_buffer[:len(self._input_buffer) - 1]
+        return not ignore
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# Formatter
+# ----------------------------------------------------------------------------------------------------------------------
+class OutputFormat:
+    #: format used to display normal messages
+    NormalMessageFormat = 0
+    #: format used to display normal messages
+    ErrorMessageFormat = 1
+    #: format used to display custom messages
+    CustomFormat = 2
+
+
+class OutputFormatter:
+    @property
+    def color_scheme(self):
+        return self._color_scheme
+
+    @color_scheme.setter
+    def color_scheme(self, new_theme):
+        self._color_scheme = new_theme
+        self._init_formats()
+        self._parser.color_scheme = new_theme
+
+    def __init__(self, text_edit, color_scheme=None):
+        if text_edit is None:
+            raise ValueError('text_edit parameter cannot be None')
+        self._last_cursor_pos = 0
+        self._text_edit = text_edit
+        self._parser = AnsiEscapeCodeParser()
+        self._cursor = text_edit.textCursor()
+        self._formats = {}
+        self._overwrite_output = False
+        _init_default_scheme()
+        self._color_scheme = color_scheme
+        if self._color_scheme is None:
+            self._color_scheme = OutputWindow.DefaultColorScheme
+        self._init_formats()
+        self._parser.color_scheme = self._color_scheme
+        self.flg_bash = False
+
+    def append_message(self, text, output_format=OutputFormat.NormalMessageFormat):
+        self._append_message(text, self._formats[output_format])
+
+    def flush(self):
+        self._parser.end_format_scope()
+
+    # Utility methods
+    def _append_message(self, text, char_format):
+        self._cursor = self._text_edit.textCursor()
+        operations = self._parser.parse_text(FormattedText(text, char_format))
+        for i, operation in enumerate(operations):
+            try:
+                func = getattr(self, '_%s' % operation.command)
+            except AttributeError:
+                print('command not implemented: %r - %r' % (
+                    operation.command, operation.data))
+            else:
+                try:
+                    func(operation.data)
+                except Exception:
+                    _logger().exception('exception while running %r', operation)
+                    # uncomment next line for debugging commands
+                    self._text_edit.repaint()
+
+    def _init_formats(self):
+        theme = self._color_scheme
+        # normal message format
+        fmt = QtGui.QTextCharFormat()
+        fmt.setForeground(theme.foreground)
+        fmt.setBackground(theme.background)
+        self._formats[OutputFormat.NormalMessageFormat] = fmt
+
+        # error message
+        fmt = QtGui.QTextCharFormat()
+        fmt.setForeground(theme.error)
+        fmt.setBackground(theme.background)
+        self._formats[OutputFormat.ErrorMessageFormat] = fmt
+
+        # debug message
+        fmt = QtGui.QTextCharFormat()
+        fmt.setForeground(theme.custom)
+        fmt.setBackground(theme.background)
+        self._formats[OutputFormat.CustomFormat] = fmt
+
+    # Commands implementation
+    def _draw(self, data):
+        self._cursor.clearSelection()
+        self._cursor.setPosition(self._last_cursor_pos)
+
+        if '\x07' in data.txt:
+            print('\a')
+        txt = data.txt.replace('\x07', '')
+
+        if '\x08' in txt:
+            parts = txt.split('\x08')
+        else:
+            parts = [txt]
+
+        self._cursor.beginEditBlock()
+
+        for i, part in enumerate(parts):
+            if part:
+                part = part.replace('\r\r', '\r')
+                if len(part) >= 80 * 24 * 8:
+                    # big output, process it in one step (\r and \n will not be handled)
+                    self._draw_chars(data, part)
+                    continue
+                to_draw = ''
+                for n, char in enumerate(part):
+                    if char == '\n':
+                        self._draw_chars(data, to_draw)
+                        to_draw = ''
+                        self._linefeed()
+                    elif char == '\r':
+                        self._draw_chars(data, to_draw)
+                        to_draw = ''
+                        self._erase_in_line(0)
+                        if self._cursor.positionInBlock() > 80 and self.flg_bash:
+                            self._linefeed()
+                        self._cursor.movePosition(self._cursor.StartOfBlock)
+                        self._text_edit.setTextCursor(self._cursor)
+                    else:
+                        to_draw += char
+                if to_draw:
+                    self._draw_chars(data, to_draw)
+            if i != len(parts) - 1:
+                self._cursor_back(1)
+        self._last_cursor_pos = self._cursor.position()
+        self._cursor.endEditBlock()
+        self._text_edit.setTextCursor(self._cursor)
+
+    def _draw_chars(self, data, to_draw):
+        i = 0
+        while not self._cursor.atBlockEnd() and i < len(to_draw) and len(to_draw) > 1:
+            self._cursor.deleteChar()
+            i += 1
+        self._cursor.insertText(to_draw, data.fmt)
+
+    def _linefeed(self):
+        last_line = self._cursor.blockNumber() == self._text_edit.blockCount() - 1
+        if self._cursor.atEnd() or last_line:
+            if last_line:
+                self._cursor.movePosition(self._cursor.EndOfBlock)
+            self._cursor.insertText('\n')
+        else:
+            self._cursor.movePosition(self._cursor.Down)
+            self._cursor.movePosition(self._cursor.StartOfBlock)
+
+    def _cursor_down(self, value):
+        self._cursor.clearSelection()
+        if self._cursor.atEnd():
+            self._cursor.insertText('\n')
+        else:
+            self._cursor.movePosition(self._cursor.Down, self._cursor.MoveAnchor, value)
+        self._last_cursor_pos = self._cursor.position()
+
+    def _cursor_up(self, value):
+        value = int(value)
+        if value == 0:
+            value = 1
+        self._cursor.clearSelection()
+        self._cursor.movePosition(self._cursor.Up, self._cursor.MoveAnchor, value)
+        self._last_cursor_pos = self._cursor.position()
+
+    def _cursor_position(self, data):
+        column, line = self._get_line_and_col(data)
+        self._move_cursor_to_line(line)
+        self._move_cursor_to_column(column)
+        self._last_cursor_pos = self._cursor.position()
+
+    def _move_cursor_to_column(self, column):
+        last_col = len(self._cursor.block().text())
+        self._cursor.movePosition(self._cursor.EndOfBlock)
+        to_insert = ''
+        for i in range(column - last_col):
+            to_insert += ' '
+        if to_insert:
+            self._cursor.insertText(to_insert)
+        self._cursor.movePosition(self._cursor.StartOfBlock)
+        self._cursor.movePosition(self._cursor.Right, self._cursor.MoveAnchor, column)
+        self._last_cursor_pos = self._cursor.position()
+
+    def _move_cursor_to_line(self, line):
+        last_line = self._text_edit.document().blockCount() - 1
+        self._cursor.clearSelection()
+        self._cursor.movePosition(self._cursor.End)
+        to_insert = ''
+        for i in range(line - last_line):
+            to_insert += '\n'
+        if to_insert:
+            self._cursor.insertText(to_insert)
+        self._cursor.movePosition(self._cursor.Start)
+        self._cursor.movePosition(self._cursor.Down, self._cursor.MoveAnchor, line)
+        self._last_cursor_pos = self._cursor.position()
+
+    def _cursor_horizontal_absolute(self, column):
+        self._move_cursor_to_column(int(column) - 1)
+
+    @staticmethod
+    def _get_line_and_col(data):
+        try:
+            line, column = data.split(';')
+        except AttributeError:
+            line = int(data)
+            column = 1
+        # handle empty values and convert them to 0 based indices
+        if not line:
+            line = 0
+        else:
+            line = int(line) - 1
+            if line < 0:
+                line = 0
+        if not column:
+            column = 0
+        else:
+            column = int(column) - 1
+            if column < 0:
+                column = 0
+        return column, line
+
+    def _erase_in_line(self, value):
+        initial_pos = self._cursor.position()
+        if value == 0:
+            # delete end of line
+            self._cursor.movePosition(self._cursor.EndOfBlock, self._cursor.KeepAnchor)
+        elif value == 1:
+            # delete start of line
+            self._cursor.movePosition(self._cursor.StartOfBlock, self._cursor.KeepAnchor)
+        else:
+            # delete whole line
+            self._cursor.movePosition(self._cursor.StartOfBlock)
+            self._cursor.movePosition(self._cursor.EndOfBlock, self._cursor.KeepAnchor)
+        self._cursor.insertText(' ' * len(self._cursor.selectedText()))
+        self._cursor.setPosition(initial_pos)
+        self._text_edit.setTextCursor(self._cursor)
+        self._last_cursor_pos = self._cursor.position()
+
+    def _erase_display(self, value):
+        if value == 0:
+            # delete end of line
+            self._cursor.movePosition(self._cursor.End, self._cursor.KeepAnchor)
+        elif value == 1:
+            # delete start of line
+            self._cursor.movePosition(self._cursor.Start, self._cursor.KeepAnchor)
+        else:
+            # delete whole line
+            self._cursor.movePosition(self._cursor.Start)
+            self._cursor.movePosition(self._cursor.End, self._cursor.KeepAnchor)
+        self._cursor.removeSelectedText()
+        self._last_cursor_pos = self._cursor.position()
+
+    def _cursor_back(self, value):
+        if value <= 0:
+            value = 1
+        self._cursor.movePosition(self._cursor.Left, self._cursor.MoveAnchor, value)
+        self._text_edit.setTextCursor(self._cursor)
+        self._last_cursor_pos = self._cursor.position()
+
+    def _cursor_forward(self, value):
+        if value <= 0:
+            value = 1
+        self._cursor.movePosition(self._cursor.Right, self._cursor.MoveAnchor, value)
+        self._text_edit.setTextCursor(self._cursor)
+        self._last_cursor_pos = self._cursor.position()
+
+    def _delete_chars(self, value):
+        value = int(value)
+        if value <= 0:
+            value = 1
+        for i in range(value):
+            self._cursor.deleteChar()
+        self._text_edit.setTextCursor(self._cursor)
+        self._last_cursor_pos = self._cursor.position()
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# Color schemes definition
+# ----------------------------------------------------------------------------------------------------------------------
+def _init_default_scheme():
+    """
+    Initialises the default color scheme with colors based on QPalette.
+
+    Call this function once after QApplication has been created (otherwise QPalette cannot be used).
+    """
+    if OutputWindow.DefaultColorScheme is None:
+        OutputWindow.DefaultColorScheme = OutputWindow.create_color_scheme()
+
+
+OutputWindow.LinuxColorScheme = OutputWindow.create_color_scheme(
+    background=QColor('black'), foreground=QColor('white'), red=QColor('#FF5555'), green=QColor('#55FF55'),
+    yellow=QColor('#FFFF55'), blue=QColor('#5555FF'), magenta=QColor('#FF55FF'), cyan=QColor('#55FFFF'))
+#: Tango theme (black background with pastel colors).
+OutputWindow.TangoColorScheme = OutputWindow.create_color_scheme(
+    background=QColor('black'), foreground=QColor('white'), red=QColor('#CC0000'), green=QColor('#4E9A06'),
+    yellow=QColor('#C4A000'), blue=QColor('#3465A4'), magenta=QColor('#75507B'), cyan=QColor('#06989A'))
+#: The famous Solarized dark theme.
+OutputWindow.SolarizedColorScheme = OutputWindow.create_color_scheme(
+    background=QColor('#073642'), foreground=QColor('#EEE8D5'), red=QColor('#DC322F'), green=QColor('#859900'),
+    yellow=QColor('#B58900'), blue=QColor('#268BD2'), magenta=QColor('#D33682'), cyan=QColor('#2AA198'))
+
+
+def _logger():
+    """
+    Returns a logger instance for this module.
+    """
+    return logging.getLogger(__name__)
+
+
+def pty_wrapper_main():
+    """
+    Main function of the pty wrapper script
+    """
+    import pty
+    # fixme: find a way to use a pty and keep stdout and stderr as separate channels
+    pty.spawn(sys.argv[1:])
+
+
+if __name__ == '__main__':
+    pty_wrapper_main()

--- a/pyqode/core/widgets/output_window.py
+++ b/pyqode/core/widgets/output_window.py
@@ -65,6 +65,10 @@ class OutputWindow(CodeEdit):
     process_finished = QtCore.Signal()
 
     @property
+    def process(self):
+        return self._process
+
+    @property
     def is_running(self):
         return self._process.state() == self._process.Running
 

--- a/pyqode/core/widgets/output_window.py
+++ b/pyqode/core/widgets/output_window.py
@@ -727,10 +727,14 @@ def _qkey_to_ascii(event):
     """
     (Try to) convert the Qt key event to the corresponding ASCII sequence for
     the terminal. This works fine for standard alphanumerical characters, but
-    most other characters require terminal specific control sequences.
+    most other characters require terminal specific control_modifier sequences.
     The conversion below works for TERM="linux' terminals.
     """
-    if event.modifiers() == QtCore.Qt.ControlModifier:
+    if sys.platform == 'darwin':
+        control_modifier = QtCore.Qt.MetaModifier
+    else:
+        control_modifier = QtCore.Qt.ControlModifier
+    if event.modifiers() == control_modifier:
         if event.key() == QtCore.Qt.Key_P:
             return b'\x10'
         elif event.key() == QtCore.Qt.Key_N:

--- a/pyqode/core/widgets/output_window.py
+++ b/pyqode/core/widgets/output_window.py
@@ -70,7 +70,7 @@ class OutputWindow(CodeEdit):
 
     @property
     def is_running(self):
-        return self._process.state() == self._process.Running
+        return self._process.state() in [self._process.Running, self._process.Starting]
 
     @property
     def color_scheme(self):

--- a/pyqode/core/widgets/output_window.py
+++ b/pyqode/core/widgets/output_window.py
@@ -984,7 +984,11 @@ class OutputFormatter:
                         self._draw_chars(data, to_draw)
                         to_draw = ''
                         self._erase_in_line(0)
-                        if self._cursor.positionInBlock() > 80 and self.flg_bash:
+                        try:
+                            nchar = part[n + 1]
+                        except IndexError:
+                            nchar = None
+                        if self._cursor.positionInBlock() > 80 and self.flg_bash and nchar != '\n':
                             self._linefeed()
                         self._cursor.movePosition(self._cursor.StartOfBlock)
                         self._text_edit.setTextCursor(self._cursor)
@@ -1013,6 +1017,7 @@ class OutputFormatter:
         else:
             self._cursor.movePosition(self._cursor.Down)
             self._cursor.movePosition(self._cursor.StartOfBlock)
+        self._text_edit.setTextCursor(self._cursor)
 
     def _cursor_down(self, value):
         self._cursor.clearSelection()

--- a/pyqode/core/widgets/output_window.py
+++ b/pyqode/core/widgets/output_window.py
@@ -126,7 +126,7 @@ class OutputWindow(CodeEdit):
         self.flg_use_pty = False
 
     def start_process(self, program, arguments=None, working_dir=None, print_command=True,
-                      use_pseudo_terminal=False, env=None):
+                      use_pseudo_terminal=True, env=None):
         """
         Starts the child process.
 

--- a/pyqode/core/widgets/output_window.py
+++ b/pyqode/core/widgets/output_window.py
@@ -967,8 +967,6 @@ class OutputFormatter:
         else:
             parts = [txt]
 
-        self._cursor.beginEditBlock()
-
         for i, part in enumerate(parts):
             if part:
                 part = part.replace('\r\r', '\r')
@@ -997,7 +995,6 @@ class OutputFormatter:
             if i != len(parts) - 1:
                 self._cursor_back(1)
         self._last_cursor_pos = self._cursor.position()
-        self._cursor.endEditBlock()
         self._text_edit.setTextCursor(self._cursor)
 
     def _draw_chars(self, data, to_draw):

--- a/pyqode/core/widgets/output_window.py
+++ b/pyqode/core/widgets/output_window.py
@@ -162,7 +162,7 @@ class OutputWindow(CodeEdit):
                                            output_format=OutputFormat.CustomFormat)
         self._process.start(pgm, args)
 
-    def terminate_process(self):
+    def stop_process(self):
         """
         Terminates the child process.
         """
@@ -249,7 +249,7 @@ class OutputWindow(CodeEdit):
         Terminates the child process on close.
         """
         super(OutputWindow, self).closeEvent(event)
-        self.terminate_process()
+        self.stop_process()
         self.backend.stop()
 
     def keyPressEvent(self, event):

--- a/pyqode/core/widgets/output_window.py
+++ b/pyqode/core/widgets/output_window.py
@@ -1177,7 +1177,7 @@ def pty_wrapper_main():
     """
     Main function of the pty wrapper script
     """
-    import pty
+    from pyqode.core.widgets import pty
     # fixme: find a way to use a pty and keep stdout and stderr as separate channels
     pty.spawn(sys.argv[1:])
 

--- a/pyqode/core/widgets/pty.py
+++ b/pyqode/core/widgets/pty.py
@@ -1,0 +1,182 @@
+"""Pseudo terminal utilities."""
+
+# Bugs: No signal handling.  Doesn't set slave termios and window size.
+#       Only tested on Linux.
+# See:  W. Richard Stevens. 1992.  Advanced Programming in the
+#       UNIX Environment.  Chapter 19.
+# Author: Steen Lumholt -- with additions by Guido.
+
+from select import select
+import os
+import tty
+
+__all__ = ["openpty","fork","spawn"]
+
+STDIN_FILENO = 0
+STDOUT_FILENO = 1
+STDERR_FILENO = 2
+
+CHILD = 0
+
+def openpty():
+    """openpty() -> (master_fd, slave_fd)
+    Open a pty master/slave pair, using os.openpty() if possible."""
+
+    try:
+        return os.openpty()
+    except (AttributeError, OSError):
+        pass
+    master_fd, slave_name = _open_terminal()
+    slave_fd = slave_open(slave_name)
+    return master_fd, slave_fd
+
+def master_open():
+    """master_open() -> (master_fd, slave_name)
+    Open a pty master and return the fd, and the filename of the slave end.
+    Deprecated, use openpty() instead."""
+
+    try:
+        master_fd, slave_fd = os.openpty()
+    except (AttributeError, OSError):
+        pass
+    else:
+        slave_name = os.ttyname(slave_fd)
+        os.close(slave_fd)
+        return master_fd, slave_name
+
+    return _open_terminal()
+
+def _open_terminal():
+    """Open pty master and return (master_fd, tty_name)."""
+    for x in 'pqrstuvwxyzPQRST':
+        for y in '0123456789abcdef':
+            pty_name = '/dev/pty' + x + y
+            try:
+                fd = os.open(pty_name, os.O_RDWR)
+            except OSError:
+                continue
+            return (fd, '/dev/tty' + x + y)
+    raise OSError('out of pty devices')
+
+def slave_open(tty_name):
+    """slave_open(tty_name) -> slave_fd
+    Open the pty slave and acquire the controlling terminal, returning
+    opened filedescriptor.
+    Deprecated, use openpty() instead."""
+
+    result = os.open(tty_name, os.O_RDWR)
+    try:
+        from fcntl import ioctl, I_PUSH
+    except ImportError:
+        return result
+    try:
+        ioctl(result, I_PUSH, "ptem")
+        ioctl(result, I_PUSH, "ldterm")
+    except OSError:
+        pass
+    return result
+
+def fork():
+    """fork() -> (pid, master_fd)
+    Fork and make the child a session leader with a controlling terminal."""
+
+    try:
+        pid, fd = os.forkpty()
+    except (AttributeError, OSError):
+        pass
+    else:
+        if pid == CHILD:
+            try:
+                os.setsid()
+            except OSError:
+                # os.forkpty() already set us session leader
+                pass
+        return pid, fd
+
+    master_fd, slave_fd = openpty()
+    pid = os.fork()
+    if pid == CHILD:
+        # Establish a new session.
+        os.setsid()
+        os.close(master_fd)
+
+        # Slave becomes stdin/stdout/stderr of child.
+        os.dup2(slave_fd, STDIN_FILENO)
+        os.dup2(slave_fd, STDOUT_FILENO)
+        os.dup2(slave_fd, STDERR_FILENO)
+        if (slave_fd > STDERR_FILENO):
+            os.close (slave_fd)
+
+        # Explicitly open the tty to make it become a controlling tty.
+        tmp_fd = os.open(os.ttyname(STDOUT_FILENO), os.O_RDWR)
+        os.close(tmp_fd)
+    else:
+        os.close(slave_fd)
+
+    # Parent and child process.
+    return pid, master_fd
+
+def _writen(fd, data):
+    """Write all the data to a descriptor."""
+    while data:
+        n = os.write(fd, data)
+        data = data[n:]
+
+def _read(fd):
+    """Default read function."""
+    return os.read(fd, 1024)
+
+def _copy(master_fd, master_read=_read, stdin_read=_read):
+    """Parent copy loop.
+    Copies
+            pty master -> standard output   (master_read)
+            standard input -> pty master    (stdin_read)"""
+    fds = [master_fd, STDIN_FILENO]
+    while True:
+        rfds, wfds, xfds = select(fds, [], [])
+        if master_fd in rfds:
+            data = master_read(master_fd)
+            if not data:  # Reached EOF.
+                return
+            else:
+                os.write(STDOUT_FILENO, data)
+        if STDIN_FILENO in rfds:
+            data = stdin_read(STDIN_FILENO)
+            if not data:
+                fds.remove(STDIN_FILENO)
+            else:
+                _writen(master_fd, data)
+
+def spawn(argv, master_read=_read, stdin_read=_read):
+    """Create a spawned process."""
+    if type(argv) == type(''):
+        argv = (argv,)
+    pid, master_fd = fork()
+    if pid == CHILD:
+        try:
+            os.execlp(argv[0], *argv)
+        except:
+            # If we wanted to be really clever, we would use
+            # the same method as subprocess() to pass the error
+            # back to the parent.  For now just dump stack trace.
+            traceback.print_exc()
+        finally:
+            os._exit(1)
+    try:
+        mode = tty.tcgetattr(STDIN_FILENO)
+        tty.setraw(STDIN_FILENO)
+        restore = 1
+    except tty.error:    # This is the same as termios.error
+        restore = 0
+    try:
+        _copy(master_fd, master_read, stdin_read)
+    except OSError:
+        # Some OSes never return an EOF on pty, just raise
+        # an error instead.
+        pass
+    finally:
+        if restore:
+            tty.tcsetattr(STDIN_FILENO, tty.TCSAFLUSH, mode)
+
+    os.close(master_fd)
+    return os.waitpid(pid, 0)[1]

--- a/pyqode/core/widgets/terminal.py
+++ b/pyqode/core/widgets/terminal.py
@@ -1,0 +1,52 @@
+import os
+import sys
+
+from . import output_window
+
+
+class Terminal(output_window.OutputWindow):
+    """
+    Simple (rudimentary) terminal widget.
+
+    It will run cmd.exe on Windows and bash on GNU/Linux.
+
+    Please note that this widget does not support all VT100 features, only the most basic one. The goal is to have
+    a small widget for running commands in a PyQt application, it does not aim to be a perfect emulator,
+    just a quick one.
+    """
+    def __init__(self, parent=None, color_scheme=None):
+        if sys.platform == 'win32':
+            input_handler = output_window.BufferedInputHandler()
+            program = 'cmd.exe'
+            args = []
+            use_pty = False
+            flg_bash = False
+        else:
+            program = 'bash'
+            args = ['-l']
+            input_handler = output_window.ImmediateInputHandler()
+            use_pty = True
+            flg_bash = True
+        working_dir = os.path.expanduser('~')
+        super(Terminal, self).__init__(parent=parent, color_scheme=color_scheme, input_handler=input_handler)
+        self._formatter.flg_bash = flg_bash
+        self.start_process(program, arguments=args, print_command=False, use_pseudo_terminal=use_pty,
+                           working_dir=working_dir)
+
+    def change_directory(self, directory):
+        """
+        Changes the current directory.
+
+        Change is made by running a "cd" command followed by a "clear" command.
+        :param directory:
+        :return:
+        """
+        self._process.write(('cd %s\n' % directory).encode())
+        if sys.platform == 'win32':
+            self._process.write(b'cls\n')
+        else:
+            self._process.write(b'clear\n')
+
+    def terminate_process(self):
+        self._process.write(b'\x04')
+        self._process.waitForBytesWritten()

--- a/test/test_widgets/parsed_output.txt
+++ b/test/test_widgets/parsed_output.txt
@@ -1,0 +1,173 @@
+[colin@sirmo ~]$ msgcat --color=test
+Colors (foreground/background):
+       |black  |blue   |green  |cyan   |red    |magenta|yellow |white  |default
+black  | Words | Words | Words | Words | Words | Words | Words | Words | Words 
+blue   | Words | Words | Words | Words | Words | Words | Words | Words | Words 
+green  | Words | Words | Words | Words | Words | Words | Words | Words | Words 
+cyan   | Words | Words | Words | Words | Words | Words | Words | Words | Words 
+red    | Words | Words | Words | Words | Words | Words | Words | Words | Words 
+magenta| Words | Words | Words | Words | Words | Words | Words | Words | Words 
+yellow | Words | Words | Words | Words | Words | Words | Words | Words | Words 
+white  | Words | Words | Words | Words | Words | Words | Words | Words | Words 
+default| Words | Words | Words | Words | Words | Words | Words | Words | Words 
+
+Colors (hue/saturation):
+red:                                                                      
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+yellow:                                                                   
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+green:                                                                    
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+cyan:                                                                     
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+blue:                                                                     
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+magenta:                                                                  
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+                                                                          
+red:                                                                      
+
+Weights:
+normal, bold, default 
+
+Postures:
+normal, italic, default 
+
+Text decorations:
+normal, underlined, default 
+
+Colors (foreground) mixed with attributes:
+black  |normal|bold|normal|italic|normal|underlined|normal|
+       |normal|bold+italic|normal|bold+underl|normal|italic+underl|normal|
+blue   |normal|bold|normal|italic|normal|underlined|normal|
+       |normal|bold+italic|normal|bold+underl|normal|italic+underl|normal|
+green  |normal|bold|normal|italic|normal|underlined|normal|
+       |normal|bold+italic|normal|bold+underl|normal|italic+underl|normal|
+cyan   |normal|bold|normal|italic|normal|underlined|normal|
+       |normal|bold+italic|normal|bold+underl|normal|italic+underl|normal|
+red    |normal|bold|normal|italic|normal|underlined|normal|
+       |normal|bold+italic|normal|bold+underl|normal|italic+underl|normal|
+magenta|normal|bold|normal|italic|normal|underlined|normal|
+       |normal|bold+italic|normal|bold+underl|normal|italic+underl|normal|
+yellow |normal|bold|normal|italic|normal|underlined|normal|
+       |normal|bold+italic|normal|bold+underl|normal|italic+underl|normal|
+white  |normal|bold|normal|italic|normal|underlined|normal|
+       |normal|bold+italic|normal|bold+underl|normal|italic+underl|normal|
+default|normal|bold|normal|italic|normal|underlined|normal|
+       |normal|bold+italic|normal|bold+underl|normal|italic+underl|normal|
+
+Colors (background) mixed with attributes:
+black  |normal|bold|normal|italic|normal|underlined|normal|
+       |normal|bold+italic|normal|bold+underl|normal|italic+underl|normal|
+blue   |normal|bold|normal|italic|normal|underlined|normal|
+       |normal|bold+italic|normal|bold+underl|normal|italic+underl|normal|
+green  |normal|bold|normal|italic|normal|underlined|normal|
+       |normal|bold+italic|normal|bold+underl|normal|italic+underl|normal|
+cyan   |normal|bold|normal|italic|normal|underlined|normal|
+       |normal|bold+italic|normal|bold+underl|normal|italic+underl|normal|
+red    |normal|bold|normal|italic|normal|underlined|normal|
+       |normal|bold+italic|normal|bold+underl|normal|italic+underl|normal|
+magenta|normal|bold|normal|italic|normal|underlined|normal|
+       |normal|bold+italic|normal|bold+underl|normal|italic+underl|normal|
+yellow |normal|bold|normal|italic|normal|underlined|normal|
+       |normal|bold+italic|normal|bold+underl|normal|italic+underl|normal|
+white  |normal|bold|normal|italic|normal|underlined|normal|
+       |normal|bold+italic|normal|bold+underl|normal|italic+underl|normal|
+default|normal|bold|normal|italic|normal|underlined|normal|
+       |normal|bold+italic|normal|bold+underl|normal|italic+underl|normal|
+
+[colin@sirmo ~]$ 

--- a/test/test_widgets/raw_output.txt
+++ b/test/test_widgets/raw_output.txt
@@ -1,0 +1,173 @@
+]0;colin@sirmo:/home/colin[colin@sirmo ~]$ msgcat --color=test
+Colors (foreground/background):
+       |black  |blue   |green  |cyan   |red    |magenta|yellow |white  |default
+black  |[30m[40m Words [39;49m|[30m[44m Words [39;49m|[30m[42m Words [39;49m|[30m[46m Words [39;49m|[30m[41m Words [39;49m|[30m[45m Words [39;49m|[30m[43m Words [39;49m|[30m[47m Words [39;49m|[30m Words [39;49m
+blue   |[34m[40m Words [39;49m|[34m[44m Words [39;49m|[34m[42m Words [39;49m|[34m[46m Words [39;49m|[34m[41m Words [39;49m|[34m[45m Words [39;49m|[34m[43m Words [39;49m|[34m[47m Words [39;49m|[34m Words [39;49m
+green  |[32m[40m Words [39;49m|[32m[44m Words [39;49m|[32m[42m Words [39;49m|[32m[46m Words [39;49m|[32m[41m Words [39;49m|[32m[45m Words [39;49m|[32m[43m Words [39;49m|[32m[47m Words [39;49m|[32m Words [39;49m
+cyan   |[36m[40m Words [39;49m|[36m[44m Words [39;49m|[36m[42m Words [39;49m|[36m[46m Words [39;49m|[36m[41m Words [39;49m|[36m[45m Words [39;49m|[36m[43m Words [39;49m|[36m[47m Words [39;49m|[36m Words [39;49m
+red    |[31m[40m Words [39;49m|[31m[44m Words [39;49m|[31m[42m Words [39;49m|[31m[46m Words [39;49m|[31m[41m Words [39;49m|[31m[45m Words [39;49m|[31m[43m Words [39;49m|[31m[47m Words [39;49m|[31m Words [39;49m
+magenta|[35m[40m Words [39;49m|[35m[44m Words [39;49m|[35m[42m Words [39;49m|[35m[46m Words [39;49m|[35m[41m Words [39;49m|[35m[45m Words [39;49m|[35m[43m Words [39;49m|[35m[47m Words [39;49m|[35m Words [39;49m
+yellow |[33m[40m Words [39;49m|[33m[44m Words [39;49m|[33m[42m Words [39;49m|[33m[46m Words [39;49m|[33m[41m Words [39;49m|[33m[45m Words [39;49m|[33m[43m Words [39;49m|[33m[47m Words [39;49m|[33m Words [39;49m
+white  |[37m[40m Words [39;49m|[37m[44m Words [39;49m|[37m[42m Words [39;49m|[37m[46m Words [39;49m|[37m[41m Words [39;49m|[37m[45m Words [39;49m|[37m[43m Words [39;49m|[37m[47m Words [39;49m|[37m Words [39;49m
+default|[40m Words [39;49m|[44m Words [39;49m|[42m Words [39;49m|[46m Words [39;49m|[41m Words [39;49m|[45m Words [39;49m|[43m Words [39;49m|[47m Words [39;49m| Words 
+
+Colors (hue/saturation):
+red:     [41m                                                            [47m     [39;49m
+         [41m                                                            [47m     [39;49m
+         [41m                                                            [47m     [39;49m
+         [41m                                                            [47m     [39;49m
+         [41m                                                            [47m     [39;49m
+         [41m                                                            [47m     [39;49m
+         [41m                                                            [47m     [39;49m
+         [41m                                                            [47m     [39;49m
+         [41m                                                            [47m     [39;49m
+         [43m                                                            [47m     [39;49m
+         [43m                                                            [47m     [39;49m
+         [43m                                                            [47m     [39;49m
+         [43m                                                            [47m     [39;49m
+         [43m                                                            [47m     [39;49m
+         [43m                                                            [47m     [39;49m
+         [43m                                                            [47m     [39;49m
+         [43m                                                            [47m     [39;49m
+         [43m                                                            [47m     [39;49m
+yellow:  [43m                                                            [47m     [39;49m
+         [43m                                                            [47m     [39;49m
+         [43m                                                            [47m     [39;49m
+         [43m                                                            [47m     [39;49m
+         [43m                                                            [47m     [39;49m
+         [43m                                                            [47m     [39;49m
+         [43m                                                            [47m     [39;49m
+         [43m                                                            [47m     [39;49m
+         [43m                                                            [47m     [39;49m
+         [42m                                                            [47m     [39;49m
+         [42m                                                            [47m     [39;49m
+         [42m                                                            [47m     [39;49m
+         [42m                                                            [47m     [39;49m
+         [42m                                                            [47m     [39;49m
+         [42m                                                            [47m     [39;49m
+         [42m                                                            [47m     [39;49m
+         [42m                                                            [47m     [39;49m
+         [42m                                                            [47m     [39;49m
+green:   [42m                                                            [47m     [39;49m
+         [42m                                                            [47m     [39;49m
+         [42m                                                            [47m     [39;49m
+         [42m                                                            [47m     [39;49m
+         [42m                                                            [47m     [39;49m
+         [42m                                                            [47m     [39;49m
+         [42m                                                            [47m     [39;49m
+         [42m                                                            [47m     [39;49m
+         [42m                                                            [47m     [39;49m
+         [46m                                                            [47m     [39;49m
+         [46m                                                            [47m     [39;49m
+         [46m                                                            [47m     [39;49m
+         [46m                                                            [47m     [39;49m
+         [46m                                                            [47m     [39;49m
+         [46m                                                            [47m     [39;49m
+         [46m                                                            [47m     [39;49m
+         [46m                                                            [47m     [39;49m
+         [46m                                                            [47m     [39;49m
+cyan:    [46m                                                            [47m     [39;49m
+         [46m                                                            [47m     [39;49m
+         [46m                                                            [47m     [39;49m
+         [46m                                                            [47m     [39;49m
+         [46m                                                            [47m     [39;49m
+         [46m                                                            [47m     [39;49m
+         [46m                                                            [47m     [39;49m
+         [46m                                                            [47m     [39;49m
+         [46m                                                            [47m     [39;49m
+         [44m                                                            [47m     [39;49m
+         [44m                                                            [47m     [39;49m
+         [44m                                                            [47m     [39;49m
+         [44m                                                            [47m     [39;49m
+         [44m                                                            [47m     [39;49m
+         [44m                                                            [47m     [39;49m
+         [44m                                                            [47m     [39;49m
+         [44m                                                            [47m     [39;49m
+         [44m                                                            [47m     [39;49m
+blue:    [44m                                                            [47m     [39;49m
+         [44m                                                            [47m     [39;49m
+         [44m                                                            [47m     [39;49m
+         [44m                                                            [47m     [39;49m
+         [44m                                                            [47m     [39;49m
+         [44m                                                            [47m     [39;49m
+         [44m                                                            [47m     [39;49m
+         [44m                                                            [47m     [39;49m
+         [44m                                                            [47m     [39;49m
+         [45m                                                            [47m     [39;49m
+         [45m                                                            [47m     [39;49m
+         [45m                                                            [47m     [39;49m
+         [45m                                                            [47m     [39;49m
+         [45m                                                            [47m     [39;49m
+         [45m                                                            [47m     [39;49m
+         [45m                                                            [47m     [39;49m
+         [45m                                                            [47m     [39;49m
+         [45m                                                            [47m     [39;49m
+magenta: [45m                                                            [47m     [39;49m
+         [45m                                                            [47m     [39;49m
+         [45m                                                            [47m     [39;49m
+         [45m                                                            [47m     [39;49m
+         [45m                                                            [47m     [39;49m
+         [45m                                                            [47m     [39;49m
+         [45m                                                            [47m     [39;49m
+         [45m                                                            [47m     [39;49m
+         [45m                                                            [47m     [39;49m
+         [41m                                                            [47m     [39;49m
+         [41m                                                            [47m     [39;49m
+         [41m                                                            [47m     [39;49m
+         [41m                                                            [47m     [39;49m
+         [41m                                                            [47m     [39;49m
+         [41m                                                            [47m     [39;49m
+         [41m                                                            [47m     [39;49m
+         [41m                                                            [47m     [39;49m
+red:     [41m                                                            [47m     [39;49m
+
+Weights:
+normal, [1mbold, (B[mdefault 
+
+Postures:
+normal, [3mitalic, [23mdefault 
+
+Text decorations:
+normal, [4munderlined, [24mdefault 
+
+Colors (foreground) mixed with attributes:
+black  [30m|normal|[1mbold(B[m[30m|normal|[3mitalic[23m[30m|normal|[4munderlined[24m[30m|normal|[39;49m
+       [30m|normal|[1m[3mbold+italic[23m(B[m[30m|normal|[1m[4mbold+underl[24m(B[m[30m|normal|[3m[4mitalic+underl[23m[24m[30m|normal|[39;49m
+blue   [34m|normal|[1mbold(B[m[34m|normal|[3mitalic[23m[34m|normal|[4munderlined[24m[34m|normal|[39;49m
+       [34m|normal|[1m[3mbold+italic[23m(B[m[34m|normal|[1m[4mbold+underl[24m(B[m[34m|normal|[3m[4mitalic+underl[23m[24m[34m|normal|[39;49m
+green  [32m|normal|[1mbold(B[m[32m|normal|[3mitalic[23m[32m|normal|[4munderlined[24m[32m|normal|[39;49m
+       [32m|normal|[1m[3mbold+italic[23m(B[m[32m|normal|[1m[4mbold+underl[24m(B[m[32m|normal|[3m[4mitalic+underl[23m[24m[32m|normal|[39;49m
+cyan   [36m|normal|[1mbold(B[m[36m|normal|[3mitalic[23m[36m|normal|[4munderlined[24m[36m|normal|[39;49m
+       [36m|normal|[1m[3mbold+italic[23m(B[m[36m|normal|[1m[4mbold+underl[24m(B[m[36m|normal|[3m[4mitalic+underl[23m[24m[36m|normal|[39;49m
+red    [31m|normal|[1mbold(B[m[31m|normal|[3mitalic[23m[31m|normal|[4munderlined[24m[31m|normal|[39;49m
+       [31m|normal|[1m[3mbold+italic[23m(B[m[31m|normal|[1m[4mbold+underl[24m(B[m[31m|normal|[3m[4mitalic+underl[23m[24m[31m|normal|[39;49m
+magenta[35m|normal|[1mbold(B[m[35m|normal|[3mitalic[23m[35m|normal|[4munderlined[24m[35m|normal|[39;49m
+       [35m|normal|[1m[3mbold+italic[23m(B[m[35m|normal|[1m[4mbold+underl[24m(B[m[35m|normal|[3m[4mitalic+underl[23m[24m[35m|normal|[39;49m
+yellow [33m|normal|[1mbold(B[m[33m|normal|[3mitalic[23m[33m|normal|[4munderlined[24m[33m|normal|[39;49m
+       [33m|normal|[1m[3mbold+italic[23m(B[m[33m|normal|[1m[4mbold+underl[24m(B[m[33m|normal|[3m[4mitalic+underl[23m[24m[33m|normal|[39;49m
+white  [37m|normal|[1mbold(B[m[37m|normal|[3mitalic[23m[37m|normal|[4munderlined[24m[37m|normal|[39;49m
+       [37m|normal|[1m[3mbold+italic[23m(B[m[37m|normal|[1m[4mbold+underl[24m(B[m[37m|normal|[3m[4mitalic+underl[23m[24m[37m|normal|[39;49m
+default|normal|[1mbold(B[m|normal|[3mitalic[23m|normal|[4munderlined[24m|normal|
+       |normal|[1m[3mbold+italic[23m(B[m|normal|[1m[4mbold+underl[24m(B[m|normal|[3m[4mitalic+underl[23m[24m|normal|
+
+Colors (background) mixed with attributes:
+black  [40m|normal|[1mbold(B[m[40m|normal|[3mitalic[23m[40m|normal|[4munderlined[24m[40m|normal|[39;49m
+       [40m|normal|[1m[3mbold+italic[23m(B[m[40m|normal|[1m[4mbold+underl[24m(B[m[40m|normal|[3m[4mitalic+underl[23m[24m[40m|normal|[39;49m
+blue   [44m|normal|[1mbold(B[m[44m|normal|[3mitalic[23m[44m|normal|[4munderlined[24m[44m|normal|[39;49m
+       [44m|normal|[1m[3mbold+italic[23m(B[m[44m|normal|[1m[4mbold+underl[24m(B[m[44m|normal|[3m[4mitalic+underl[23m[24m[44m|normal|[39;49m
+green  [42m|normal|[1mbold(B[m[42m|normal|[3mitalic[23m[42m|normal|[4munderlined[24m[42m|normal|[39;49m
+       [42m|normal|[1m[3mbold+italic[23m(B[m[42m|normal|[1m[4mbold+underl[24m(B[m[42m|normal|[3m[4mitalic+underl[23m[24m[42m|normal|[39;49m
+cyan   [46m|normal|[1mbold(B[m[46m|normal|[3mitalic[23m[46m|normal|[4munderlined[24m[46m|normal|[39;49m
+       [46m|normal|[1m[3mbold+italic[23m(B[m[46m|normal|[1m[4mbold+underl[24m(B[m[46m|normal|[3m[4mitalic+underl[23m[24m[46m|normal|[39;49m
+red    [41m|normal|[1mbold(B[m[41m|normal|[3mitalic[23m[41m|normal|[4munderlined[24m[41m|normal|[39;49m
+       [41m|normal|[1m[3mbold+italic[23m(B[m[41m|normal|[1m[4mbold+underl[24m(B[m[41m|normal|[3m[4mitalic+underl[23m[24m[41m|normal|[39;49m
+magenta[45m|normal|[1mbold(B[m[45m|normal|[3mitalic[23m[45m|normal|[4munderlined[24m[45m|normal|[39;49m
+       [45m|normal|[1m[3mbold+italic[23m(B[m[45m|normal|[1m[4mbold+underl[24m(B[m[45m|normal|[3m[4mitalic+underl[23m[24m[45m|normal|[39;49m
+yellow [43m|normal|[1mbold(B[m[43m|normal|[3mitalic[23m[43m|normal|[4munderlined[24m[43m|normal|[39;49m
+       [43m|normal|[1m[3mbold+italic[23m(B[m[43m|normal|[1m[4mbold+underl[24m(B[m[43m|normal|[3m[4mitalic+underl[23m[24m[43m|normal|[39;49m
+white  [47m|normal|[1mbold(B[m[47m|normal|[3mitalic[23m[47m|normal|[4munderlined[24m[47m|normal|[39;49m
+       [47m|normal|[1m[3mbold+italic[23m(B[m[47m|normal|[1m[4mbold+underl[24m(B[m[47m|normal|[3m[4mitalic+underl[23m[24m[47m|normal|[39;49m
+default|normal|[1mbold(B[m|normal|[3mitalic[23m|normal|[4munderlined[24m|normal|
+       |normal|[1m[3mbold+italic[23m(B[m|normal|[1m[4mbold+underl[24m(B[m|normal|[3m[4mitalic+underl[23m[24m|normal|
+
+]0;colin@sirmo:/home/colin[colin@sirmo ~]$ 

--- a/test/test_widgets/test_output_window.py
+++ b/test/test_widgets/test_output_window.py
@@ -1,0 +1,43 @@
+import os
+from pyqode.core.widgets import output_window
+
+
+DIRECTORY = os.path.dirname(__file__)
+with open(os.path.join(DIRECTORY, 'raw_output.txt')) as f:
+    RAW_OUTPUT = f.read()
+with open(os.path.join(DIRECTORY, 'parsed_output.txt')) as f:
+    PARSED_OUTPUT = f.read()
+
+
+def test_parser():
+    # functional test
+    parser = output_window.AnsiEscapeCodeParser()
+    operations = parser.parse_text(output_window.FormattedText(RAW_OUTPUT))
+    assert len(operations) == 772
+
+    # check if bold+underlined is correctly set
+    op = operations[550]
+    assert op.command == 'draw'
+    assert isinstance(op.data, output_window.FormattedText)
+    from pyqode.qt import QtGui
+    assert isinstance(op.data.fmt, QtGui.QTextCharFormat)
+    assert op.data.txt == 'bold+underl'
+    assert op.data.fmt.fontUnderline() is True
+    assert op.data.fmt.font().weight() == QtGui.QFont.Bold
+
+    # check if reset format has been done
+    op = operations[551]
+    assert op.command == 'draw'
+    assert isinstance(op.data, output_window.FormattedText)
+    assert isinstance(op.data.fmt, QtGui.QTextCharFormat)
+    assert op.data.txt == '|normal|'
+    assert op.data.fmt.fontUnderline() is False
+    assert op.data.fmt.font().weight() != QtGui.QFont.Bold
+
+
+def test_output_window():
+    # functional test
+    w = output_window.OutputWindow()
+    w._formatter.append_message(RAW_OUTPUT)
+    assert w.blockCount() == 173
+    assert w.toPlainText() == PARSED_OUTPUT

--- a/test/test_widgets/test_output_window.py
+++ b/test/test_widgets/test_output_window.py
@@ -66,7 +66,7 @@ def test_buffered_input_handler():
     assert w.blockCount() == 1
     QtTest.QTest.keyPress(w, QtCore.Qt.Key_Return)
     QtTest.QTest.qWait(1000)
-    assert w.blockCount() > 2
+    assert w.blockCount() >= 2
 
 
 def test_immediate_input_handler():
@@ -80,4 +80,4 @@ def test_immediate_input_handler():
     assert w.blockCount() == 1
     QtTest.QTest.keyPress(w, QtCore.Qt.Key_Return)
     QtTest.QTest.qWait(1000)
-    assert w.blockCount() > 2
+    assert w.blockCount() >= 2


### PR DESCRIPTION
This widget can be used as a replacement for ``pyqode.core.widgets.InteractiveConsole``, it can also be used to write a rudimentary terminal emulator (see pyqode.core.widgets.terminal).

I still need to test it on Windows and OSX before I merge this branch.