### PR TITLE
Miscellaneous bugfixes

### DIFF
--- a/pyqode/core/__init__.py
+++ b/pyqode/core/__init__.py
@@ -10,7 +10,7 @@ widget, i.e. pyqode.core is a generic code editor widget.
 import logging
 
 
-__version__ = '2.12.0'
+__version__ = '2.12.1a1'
 
 
 logging.addLevelName(1, "PYQODEDEBUGCOMM")

--- a/pyqode/core/api/code_edit.py
+++ b/pyqode/core/api/code_edit.py
@@ -792,6 +792,9 @@ class CodeEdit(QtWidgets.QPlainTextEdit):
 
         :param increment: zoom level increment. Default is 1.
         """
+        # When called through an action, the first argument is a bool
+        if isinstance(increment, bool):
+            increment = 1
         self.zoom_level += increment
         TextHelper(self).mark_whole_doc_dirty()
         self._reset_stylesheet()
@@ -803,6 +806,9 @@ class CodeEdit(QtWidgets.QPlainTextEdit):
         :param decrement: zoom level decrement. Default is 1. The value is
             given as an absolute value.
         """
+        # When called through an action, the first argument is a bool
+        if isinstance(decrement, bool):
+            decrement = 1
         self.zoom_level -= decrement
         # make sure font size remains > 0
         if self.font_size + self.zoom_level <= 0:

--- a/pyqode/core/api/code_edit.py
+++ b/pyqode/core/api/code_edit.py
@@ -875,7 +875,8 @@ class CodeEdit(QtWidgets.QPlainTextEdit):
         tc.beginEditBlock()
         no_selection = False
         sText = tc.selection().toPlainText()
-        if not helper.current_line_text() and sText.count("\n") > 1:
+        # If only whitespace is selected, simply delete it
+        if not helper.current_line_text() and not sText.strip():
             tc.deleteChar()
         else:
             if not self.textCursor().hasSelection():

--- a/pyqode/core/api/code_edit.py
+++ b/pyqode/core/api/code_edit.py
@@ -524,6 +524,7 @@ class CodeEdit(QtWidgets.QPlainTextEdit):
         clone = self.clone()
         self.link(clone)
         TextHelper(clone).goto_line(l, c)
+        clone.verticalScrollBar().setValue(self.verticalScrollBar().value())
         self.clones.append(clone)
         return clone
 

--- a/pyqode/core/api/syntax_highlighter.py
+++ b/pyqode/core/api/syntax_highlighter.py
@@ -52,7 +52,7 @@ COLOR_SCHEME_KEYS = {
     # any instance variable
     "instance": Token.Name.Variable,
     # whitespace color
-    "whitespace": Token.Text.Whitespace,
+    "whitespace": Token.Comment,
     # any tag name (e.g. shinx doctags,...)
     'tag': Token.Name.Tag,
     # self paramter (or this in other languages)

--- a/pyqode/core/modes/autoindent.py
+++ b/pyqode/core/modes/autoindent.py
@@ -15,6 +15,20 @@ class AutoIndentMode(Mode):
     def __init__(self):
         super(AutoIndentMode, self).__init__()
 
+    @property
+    def _indent_char(self):
+
+        if self.editor.use_spaces_instead_of_tabs:
+            return ' '
+        return '\t'
+
+    @property
+    def _single_indent(self):
+
+        if self.editor.use_spaces_instead_of_tabs:
+            return self.editor.tab_length * ' '
+        return '\t'
+
     def _get_indent(self, cursor):
         """
         Return the indentation text (a series of spaces or tabs)
@@ -23,7 +37,7 @@ class AutoIndentMode(Mode):
 
         :returns: Tuple (text before new line, text after new line)
         """
-        indent = TextHelper(self.editor).line_indent() * ' '
+        indent = TextHelper(self.editor).line_indent() * self._indent_char
         return "", indent
 
     def on_state_changed(self, state):

--- a/pyqode/core/modes/indenter.py
+++ b/pyqode/core/modes/indenter.py
@@ -89,6 +89,7 @@ class IndenterMode(Mode):
         assert isinstance(block, QtGui.QTextBlock)
         i = 0
         debug('unindent selection: %d lines', nb_lines)
+        start_pos = block.position()
         while i < nb_lines:
             cursor.setPosition(block.position(), cursor.MoveAnchor)
             txt = block.text()
@@ -102,8 +103,12 @@ class IndenterMode(Mode):
                 txt = block.text()
                 if len(txt) and txt[0] == self._indent_char:
                     cursor.deleteChar()
+            end_pos = block.position() + block.length()
             block = block.next()
             i += 1
+        # Restore selection
+        cursor.setPosition(start_pos, cursor.MoveAnchor)
+        cursor.setPosition(end_pos, cursor.KeepAnchor)
         return cursor
 
     def indent(self):

--- a/pyqode/core/modes/indenter.py
+++ b/pyqode/core/modes/indenter.py
@@ -30,6 +30,20 @@ class IndenterMode(Mode):
     def __init__(self):
         super(IndenterMode, self).__init__()
 
+    @property
+    def _indent_char(self):
+
+        if self.editor.use_spaces_instead_of_tabs:
+            return ' '
+        return '\t'
+
+    @property
+    def _single_indent(self):
+
+        if self.editor.use_spaces_instead_of_tabs:
+            return self.editor.tab_length * ' '
+        return '\t'
+
     def on_state_changed(self, state):
         if state:
             self.editor.indent_requested.connect(self.indent)
@@ -45,7 +59,6 @@ class IndenterMode(Mode):
         :param cursor: QTextCursor
         """
         doc = self.editor.document()
-        tab_len = self.editor.tab_length
         cursor.beginEditBlock()
         nb_lines = len(cursor.selection().toPlainText().splitlines())
         c = self.editor.textCursor()
@@ -55,14 +68,9 @@ class IndenterMode(Mode):
         i = 0
         # indent every lines
         while i < nb_lines:
-            nb_space_to_add = tab_len
             cursor = QtGui.QTextCursor(block)
             cursor.movePosition(cursor.StartOfLine, cursor.MoveAnchor)
-            if self.editor.use_spaces_instead_of_tabs:
-                for _ in range(nb_space_to_add):
-                    cursor.insertText(" ")
-            else:
-                cursor.insertText('\t')
+            cursor.insertText(self._single_indent)
             block = block.next()
             i += 1
         cursor.endEditBlock()
@@ -74,7 +82,6 @@ class IndenterMode(Mode):
         :param cursor: QTextCursor
         """
         doc = self.editor.document()
-        tab_len = self.editor.tab_length
         nb_lines = len(cursor.selection().toPlainText().splitlines())
         if nb_lines == 0:
             nb_lines = 1
@@ -83,22 +90,18 @@ class IndenterMode(Mode):
         i = 0
         debug('unindent selection: %d lines', nb_lines)
         while i < nb_lines:
+            cursor.setPosition(block.position(), cursor.MoveAnchor)
             txt = block.text()
             debug('line to unindent: %s', txt)
             debug('self.editor.use_spaces_instead_of_tabs: %r',
                   self.editor.use_spaces_instead_of_tabs)
-            if self.editor.use_spaces_instead_of_tabs:
-                indentation = (len(txt) - len(txt.lstrip()))
-            else:
-                indentation = len(txt) - len(txt.replace('\t', ''))
-            debug('unindent line %d: %d spaces', i, indentation)
-            if indentation > 0:
-                c = QtGui.QTextCursor(block)
-                c.movePosition(c.StartOfLine, cursor.MoveAnchor)
-                for _ in range(tab_len):
-                    txt = block.text()
-                    if len(txt) and txt[0] == ' ':
-                        c.deleteChar()
+            indentation = len(txt) - len(txt.lstrip(self._indent_char))
+            debug('unindent line %d: %d characters', i, indentation)
+            cursor.movePosition(cursor.StartOfLine, cursor.MoveAnchor)
+            for _ in range(len(self._single_indent)):
+                txt = block.text()
+                if len(txt) and txt[0] == self._indent_char:
+                    cursor.deleteChar()
             block = block.next()
             i += 1
         return cursor
@@ -133,7 +136,7 @@ class IndenterMode(Mode):
             pos = trav_cursor.position()
             trav_cursor.movePosition(cursor.Left, cursor.KeepAnchor)
             char = trav_cursor.selectedText()
-            if char == " ":
+            if char == self._indent_char:
                 spaces += 1
             else:
                 break

--- a/pyqode/core/modes/zoom.py
+++ b/pyqode/core/modes/zoom.py
@@ -25,23 +25,38 @@ class ZoomMode(Mode):
         if state:
             self.editor.mouse_wheel_activated.connect(
                 self._on_wheel_event)
-            self.editor.key_pressed.connect(self._on_key_pressed)
-            self.mnu_zoom = QtWidgets.QMenu("Zoom")
-            a = self.mnu_zoom.addAction(QtGui.QIcon.fromTheme(
-                'zoom-in'), 'Zoom in')
+            self.mnu_zoom = QtWidgets.QMenu("Zoom", self.editor)
+            # Zoom in
+            a = QtWidgets.QAction(
+                QtGui.QIcon.fromTheme('zoom-in'),
+                'Zoom in',
+                self.editor
+            )
+            a.setShortcutContext(QtCore.Qt.WidgetShortcut)
+            self.mnu_zoom.addAction(a)
             a.setShortcut('Ctrl++')
             a.triggered.connect(self.editor.zoom_in)
-
-            a = self.mnu_zoom.addAction(QtGui.QIcon.fromTheme(
-                'zoom-out'), 'Zoom out')
+            # Zoom out
+            a = QtWidgets.QAction(
+                QtGui.QIcon.fromTheme('zoom-out'),
+                'Zoom out',
+                self.editor
+            )
+            a.setShortcutContext(QtCore.Qt.WidgetShortcut)
+            self.mnu_zoom.addAction(a)
             a.setShortcut('Ctrl+-')
             a.triggered.connect(self.editor.zoom_out)
-
-            a = self.mnu_zoom.addAction(QtGui.QIcon.fromTheme(
-                'zoom-fit-best'), 'Reset zoom')
+            # Reset zoom
+            a = QtWidgets.QAction(
+                QtGui.QIcon.fromTheme('zoom-fit-best'),
+                'Reset zoom',
+                self.editor
+            )
+            a.setShortcutContext(QtCore.Qt.WidgetShortcut)
+            self.mnu_zoom.addAction(a)
             a.setShortcut('Ctrl+0')
             a.triggered.connect(self.editor.reset_zoom)
-
+            # Zoom menu
             a = self.mnu_zoom.menuAction()
             a.setIcon(QtGui.QIcon.fromTheme('zoom'))
             self.editor.add_action(a, sub_menu=None)
@@ -50,26 +65,6 @@ class ZoomMode(Mode):
                 self._on_wheel_event)
             self.editor.remove_action(self.mnu_zoom.menuAction(),
                                       sub_menu=None)
-            self.editor.key_pressed.disconnect(self._on_key_pressed)
-
-    def _on_key_pressed(self, event):
-        """
-        Resets editor font size to the default font size
-
-        :param event: wheelEvent
-        :type event: QKeyEvent
-        """
-        if (int(event.modifiers()) & QtCore.Qt.ControlModifier > 0 and
-                not int(event.modifiers()) & QtCore.Qt.ShiftModifier):
-            if event.key() == QtCore.Qt.Key_0:
-                self.editor.reset_zoom()
-                event.accept()
-            if event.key() == QtCore.Qt.Key_Plus:
-                self.editor.zoom_in()
-                event.accept()
-            if event.key() == QtCore.Qt.Key_Minus:
-                self.editor.zoom_out()
-                event.accept()
 
     def _on_wheel_event(self, event):
         """

--- a/pyqode/core/widgets/splittable_tab_widget.py
+++ b/pyqode/core/widgets/splittable_tab_widget.py
@@ -989,7 +989,8 @@ class SplittableTabWidget(QtWidgets.QSplitter):
             # first need to set the focus to the current splitter, and then to
             # the widget.
             self.main_tab_widget.setFocus()
-            self.main_tab_widget.currentWidget().setFocus()
+            if self.main_tab_widget.currentWidget() is not None:
+                self.main_tab_widget.currentWidget().setFocus()
 
     def count(self):
         """

--- a/pyqode/core/widgets/splittable_tab_widget.py
+++ b/pyqode/core/widgets/splittable_tab_widget.py
@@ -504,6 +504,8 @@ class BaseTabWidget(QtWidgets.QTabWidget):
         :param index: index of the tab to remove.
         """
         widget = self.widget(index)
+        if widget is None:
+            return
         try:
             document = widget.document()
         except AttributeError:

--- a/pyqode/core/widgets/splittable_tab_widget.py
+++ b/pyqode/core/widgets/splittable_tab_widget.py
@@ -6,7 +6,6 @@ import logging
 import mimetypes
 import os
 import io
-import sys
 import uuid
 import weakref
 
@@ -841,12 +840,13 @@ class SplittableTabWidget(QtWidgets.QSplitter):
                 splitter.add_context_action(action)
         return splitter
 
-    def split(self, widget, orientation):
+    def split(self, widget, orientation, index=None):
         """
         Split the the current widget in new SplittableTabWidget.
 
         :param widget: widget to split
         :param orientation: orientation of the splitter
+        :param index: the index of the new splitter, or None to append
         :return: the new splitter
         """
         if widget.original:
@@ -863,8 +863,12 @@ class SplittableTabWidget(QtWidgets.QSplitter):
         self.setOrientation(orientation)
         splitter = self._make_splitter()
         splitter.show()
-        self.addWidget(splitter)
-        self.child_splitters.append(splitter)
+        if index is None:
+            self.addWidget(splitter)
+            self.child_splitters.append(splitter)
+        else:
+            self.insertWidget(index, splitter)
+            self.child_splitters.insert(index, splitter)
         if clone not in base.clones:
             # code editors maintain the list of clones internally but some
             # other widgets (user widgets) might not.
@@ -1585,9 +1589,9 @@ class SplittableCodeEditTabWidget(SplittableTabWidget):
         self.dirty_changed.emit(new.dirty)
         return old, new
 
-    def split(self, widget, orientation):
+    def split(self, widget, orientation, index=None):
         splitter = super(SplittableCodeEditTabWidget, self).split(
-            widget, orientation)
+            widget, orientation, index=index)
         if splitter:
             splitter.tab_bar_double_clicked.connect(
                 self.tab_bar_double_clicked.emit)

--- a/pyqode/core/widgets/splittable_tab_widget.py
+++ b/pyqode/core/widgets/splittable_tab_widget.py
@@ -849,44 +849,27 @@ class SplittableTabWidget(QtWidgets.QSplitter):
         :param orientation: orientation of the splitter
         :return: the new splitter
         """
-        # There are two cases, which are treated differently.
-        # 1. The current splitter contains only the current widget. If so, then
-        #    we create a new splitter that contains a clone of the current
-        #    widget and add this new splitter to the current splitter.
-        # 2. The current splitter already contains a splitter in addition to
-        #    the current widget. In that case, we create a new splitter that
-        #    contains the current widget and a clone of it, add this new
-        #    splitter to the current splitter. Finally, we remove the current
-        #    widget from the current splitter. In the end, we're left with
-        #    two splitters but no widget inside the current splitter.
-        widget_to_splitter = bool(self.child_splitters)
         if widget.original:
             base = widget.original
         else:
             base = widget
-        if not widget_to_splitter:
-            clone = base.split()
-            if not clone:
-                return
+        clone = base.split()
+        if not clone:
+            return
+        if orientation == int(QtCore.Qt.Horizontal):
+            orientation = QtCore.Qt.Horizontal
+        else:
+            orientation = QtCore.Qt.Vertical
+        self.setOrientation(orientation)
         splitter = self._make_splitter()
         splitter.show()
-        if not widget_to_splitter:
-            if orientation == int(QtCore.Qt.Horizontal):
-                orientation = QtCore.Qt.Horizontal
-            else:
-                orientation = QtCore.Qt.Vertical
-            self.setOrientation(orientation)
-            self.addWidget(splitter)
-            self.child_splitters.append(splitter)
-        else:
-            self.insertWidget(0, splitter)
-            self.child_splitters.insert(0, splitter)
-        if not widget_to_splitter:
-            if clone not in base.clones:
-                # code editors maintain the list of clones internally but some
-                # other widgets (user widgets) might not.
-                base.clones.append(clone)
-            clone.original = base
+        self.addWidget(splitter)
+        self.child_splitters.append(splitter)
+        if clone not in base.clones:
+            # code editors maintain the list of clones internally but some
+            # other widgets (user widgets) might not.
+            base.clones.append(clone)
+        clone.original = base
         splitter._parent_splitter = self
         splitter.last_tab_closed.connect(self._on_last_child_tab_closed)
         splitter.tab_detached.connect(self.tab_detached.emit)
@@ -897,27 +880,15 @@ class SplittableTabWidget(QtWidgets.QSplitter):
         # same group of tab splitter (user might have a group for editors and
         # another group for consoles or whatever).
         splitter._uuid = self._uuid
-        splitter.add_tab(
-            widget if widget_to_splitter else clone,
-            title=self.main_tab_widget.tabText(
-                self.main_tab_widget.indexOf(widget)
-            ),
-            icon=icon
-        )
+        splitter.add_tab(clone, title=self.main_tab_widget.tabText(
+            self.main_tab_widget.indexOf(widget)), icon=icon)
         self.setSizes([1 for i in range(self.count())])
-        # If the current widget is transferred to a splitter, then we close the
-        # current widget.
-        if widget_to_splitter:
-            splitter.split(widget, orientation)
-            self.main_tab_widget.close()
-            self.main_tab_widget.hide()
         # In order for the focus to switch to the newly splitted editor, it
         # appears that there first needs to be a splitter with a widget in it,
         # and then first the splitter and then the widget need to explicitly
         # receive focus. There may be a more elegant way to achieve this.
-        else:
-            splitter.main_tab_widget.setFocus()
-            clone.setFocus()
+        splitter.main_tab_widget.setFocus()
+        clone.setFocus()
         return splitter
 
     def has_children(self):
@@ -1018,8 +989,7 @@ class SplittableTabWidget(QtWidgets.QSplitter):
             # first need to set the focus to the current splitter, and then to
             # the widget.
             self.main_tab_widget.setFocus()
-            if self.main_tab_widget.currentWidget() is not None:
-                self.main_tab_widget.currentWidget().setFocus()
+            self.main_tab_widget.currentWidget().setFocus()
 
     def count(self):
         """

--- a/pyqode/core/widgets/splittable_tab_widget.py
+++ b/pyqode/core/widgets/splittable_tab_widget.py
@@ -131,7 +131,7 @@ class BaseTabWidget(QtWidgets.QTabWidget):
 
     _detached_window_class = None
 
-    def __init__(self, parent):
+    def __init__(self, parent, tab_bar_shortcuts=True):
         super(BaseTabWidget, self).__init__(parent)
         self._current = None
         self.currentChanged.connect(self._on_current_changed)
@@ -146,6 +146,7 @@ class BaseTabWidget(QtWidgets.QTabWidget):
         self.setUsesScrollButtons(True)
 
         #: A list of additional context menu actions
+        self._tab_bar_shortcuts = tab_bar_shortcuts
         self.context_actions = []
         self.a_close = None
         self.a_close_all = None
@@ -354,10 +355,12 @@ class BaseTabWidget(QtWidgets.QTabWidget):
         self.a_close_left.setVisible(0 < index <= self.count() - 1)
         self.a_close_others.setVisible(self.count() > 1)
         self.a_close_all.setVisible(self.count() > 1)
-
-        self.a_close.setShortcut('Ctrl+W')
-        self.a_close_all.setShortcut('Ctrl+Shift+W')
-
+        if self._tab_bar_shortcuts:
+            # These should not be set when multiple tabs will be visible in a
+            # splitter, because then they will become ambiguous and hence
+            # ineffective.
+            self.a_close.setShortcut('Ctrl+W')
+            self.a_close_all.setShortcut('Ctrl+Shift+W')
         self._context_mnu = context_mnu
         return context_mnu
 
@@ -731,7 +734,10 @@ class SplittableTabWidget(QtWidgets.QSplitter):
                 QtCore.Qt.Popup | QtCore.Qt.FramelessWindowHint)
             self.popup.triggered.connect(self._on_popup_triggered)
         self.child_splitters = []
-        self.main_tab_widget = self.tab_widget_klass(self)
+        self.main_tab_widget = self.tab_widget_klass(
+            self,
+            tab_bar_shortcuts=False
+        )
         self.main_tab_widget.last_tab_closed.connect(
             self._on_last_tab_closed)
         self.main_tab_widget.tab_detached.connect(self.tab_detached.emit)

--- a/pyqode/core/widgets/splittable_tab_widget.py
+++ b/pyqode/core/widgets/splittable_tab_widget.py
@@ -1544,8 +1544,6 @@ class SplittableCodeEditTabWidget(SplittableTabWidget):
 
     def _icon(self, path):
         provider = self.icon_provider_klass()
-        if not os.path.exists(path):
-            return provider.icon(provider.File)
         return provider.icon(QtCore.QFileInfo(path))
 
     def _on_current_changed(self, new):

--- a/pyqode/core/widgets/splittable_tab_widget.py
+++ b/pyqode/core/widgets/splittable_tab_widget.py
@@ -1590,6 +1590,7 @@ class SplittableCodeEditTabWidget(SplittableTabWidget):
         if splitter:
             splitter.tab_bar_double_clicked.connect(
                 self.tab_bar_double_clicked.emit)
+            splitter.fallback_editor = self.fallback_editor
         return splitter
 
     def _on_tab_closed(self, tab):

--- a/pyqode/core/widgets/splittable_tab_widget.py
+++ b/pyqode/core/widgets/splittable_tab_widget.py
@@ -552,7 +552,7 @@ class BaseTabWidget(QtWidgets.QTabWidget):
         icon = parent.tabIcon(index)
         parent.removeTab(index)
         widget.parent_tab_widget = self
-        self.insertTab(new_index, widget, icon, text)
+        new_index = self.insertTab(new_index, widget, icon, text)
         self.setCurrentIndex(new_index)
         widget.setFocus()
         if parent.count() == 0:

--- a/pyqode/core/widgets/splittable_tab_widget.py
+++ b/pyqode/core/widgets/splittable_tab_widget.py
@@ -875,6 +875,12 @@ class SplittableTabWidget(QtWidgets.QSplitter):
         splitter.add_tab(clone, title=self.main_tab_widget.tabText(
             self.main_tab_widget.indexOf(widget)), icon=icon)
         self.setSizes([1 for i in range(self.count())])
+        # In order for the focus to switch to the newly splitted editor, it
+        # appears that there first needs to be a splitter with a widget in it,
+        # and then first the splitter and then the widget need to explicitly
+        # receive focus. There may be a more elegant way to achieve this.
+        splitter.main_tab_widget.setFocus()
+        clone.setFocus()
         return splitter
 
     def has_children(self):
@@ -927,6 +933,7 @@ class SplittableTabWidget(QtWidgets.QSplitter):
                 # ensure root is visible when there are no children
                 self.show()
                 self.main_tab_widget.show()
+                self._current = None
             else:
                 # hide ourselves (we don't have any other tabs or children)
                 self._remove_from_parent()
@@ -967,6 +974,13 @@ class SplittableTabWidget(QtWidgets.QSplitter):
                 self.main_tab_widget.show()
             else:
                 self._remove_from_parent()
+        else:
+            # If a child closed its last tab, but this splitter still has a
+            # tab then we set the focus to that tab. For this to happen we
+            # first need to set the focus to the current splitter, and then to
+            # the widget.
+            self.main_tab_widget.setFocus()
+            self.main_tab_widget.currentWidget().setFocus()
 
     def count(self):
         """
@@ -1542,6 +1556,7 @@ class SplittableCodeEditTabWidget(SplittableTabWidget):
         if splitter:
             splitter.tab_bar_double_clicked.connect(
                 self.tab_bar_double_clicked.emit)
+        return splitter
 
     def _on_tab_closed(self, tab):
         try:

--- a/pyqode/core/widgets/splittable_tab_widget.py
+++ b/pyqode/core/widgets/splittable_tab_widget.py
@@ -978,6 +978,7 @@ class SplittableTabWidget(QtWidgets.QSplitter):
             if self.root:
                 self.show()
                 self.main_tab_widget.show()
+                self._current = None
             else:
                 self._remove_from_parent()
         else:

--- a/pyqode/core/widgets/splittable_tab_widget.py
+++ b/pyqode/core/widgets/splittable_tab_widget.py
@@ -429,7 +429,7 @@ class BaseTabWidget(QtWidgets.QTabWidget):
         widget = self.widget(index)
         dirty = False
         try:
-            if widget.original is None:
+            if widget.original is None and not widget.clones:
                 dirty = widget.dirty
         except AttributeError:
             pass

--- a/pyqode/core/widgets/splittable_tab_widget.py
+++ b/pyqode/core/widgets/splittable_tab_widget.py
@@ -1432,14 +1432,14 @@ class SplittableCodeEditTabWidget(SplittableTabWidget):
                 icon = self._icon(path)
                 self.add_tab(tab, title=name, icon=icon)
                 self.document_opened.emit(tab)
-
-                for action in self.closed_tabs_menu.actions():
-                    if action.toolTip() == original_path:
-                        self.closed_tabs_menu.removeAction(action)
-                        break
-                self.closed_tabs_history_btn.setEnabled(
-                    len(self.closed_tabs_menu.actions()) > 0)
-
+                # Only the root tab has a corner widget with closed tabs
+                if self.root:
+                    for action in self.closed_tabs_menu.actions():
+                        if action.toolTip() == original_path:
+                            self.closed_tabs_menu.removeAction(action)
+                            break
+                    self.closed_tabs_history_btn.setEnabled(
+                        len(self.closed_tabs_menu.actions()) > 0)
                 return tab
 
     def close_document(self, path):


### PR DESCRIPTION
I realize that pyqode is no longer actively developed, but my understanding is that bugfixes will still be merged. If not, let me know, and then I will continue this as a separate fork. (But my preference is to merge upstream.)

There are quite a few bugfixes in here. For details, see the commit messages, but in a nutshell:

- Fixed cutting/ pasting (very important!)
- Various improvements to splitting and tabbing
- Fixed indentation modes for tab-based indentation
- Fixed swapping of lines
- Fixed ineffective keyboard shortcuts when multiple editors are shown in a splitter

I will fix more issues as I encounter them, but this PR should cover the most obvious of them. Except for one remaining issue, which I haven't figured out how to solve adequately: If you split an editor once horizontally, and then split the same editor again vertically, the entire splitter will become vertical. I've fixed this in a hacky way [here](https://github.com/smathot/opensesame-extension-ide/commit/5f58a07145a64aaf8e5adb928fa3230424bf52dc), but it's not very satisfactory. (Although it works.)