### PR TITLE
Escape always closes search-replace panel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,3 +17,4 @@ recursive-include doc *
 recursive-include examples *
 recursive-include forms *
 recursive-include test *
+recursive-exclude test *.pyc

--- a/pyqode/core/__init__.py
+++ b/pyqode/core/__init__.py
@@ -10,7 +10,7 @@ widget, i.e. pyqode.core is a generic code editor widget.
 import logging
 
 
-__version__ = '2.12.1'
+__version__ = '2.12.2a4'
 
 
 logging.addLevelName(1, "PYQODEDEBUGCOMM")

--- a/pyqode/core/modes/pygments_sh.py
+++ b/pyqode/core/modes/pygments_sh.py
@@ -220,7 +220,6 @@ class PygmentsSH(SyntaxHighlighter):
             print('class not found for url', filename)
             try:
                 m = mimetypes.guess_type(filename)
-                print(m)
                 self._lexer = get_lexer_for_mimetype(m[0])
             except (ClassNotFound, IndexError, ImportError):
                 self._lexer = get_lexer_for_mimetype('text/plain')

--- a/pyqode/core/panels/search_and_replace.py
+++ b/pyqode/core/panels/search_and_replace.py
@@ -156,7 +156,7 @@ class SearchAndReplacePanel(Panel, Ui_SearchPanel):
         icon_size = QtCore.QSize(16, 16)
 
         icon = icons.icon('edit-find', ':/pyqode-icons/rc/edit-find.png',
-                          'fa.search')
+                          'fa.s    earch')
         self.actionSearch.setIcon(icon)
         self.actionSearch.setShortcut('Ctrl+F')
         self.labelSearch.setPixmap(icon.pixmap(icon_size))
@@ -269,13 +269,31 @@ class SearchAndReplacePanel(Panel, Ui_SearchPanel):
         Closes the panel
         """
         self.hide()
+        try:
+            self.editor.key_pressed.disconnect(self._on_key_pressed)
+        except TypeError:
+            # In some race conditions, for example when clicking the close
+            # button and pressing escape almost simultaneously, the signal is
+            # already disconnected
+            pass
         self.lineEditReplace.clear()
         self.lineEditSearch.clear()
+
+    def _on_key_pressed(self, event):
+
+        if event.isAccepted():
+            return
+        if not self.lineEditSearch.isVisible():
+            return
+        if event.key() == QtCore.Qt.Key_Escape:
+            self.close_panel()
+            event.accept()
 
     def on_close(self):
         self.close_panel()
 
     def on_search(self):
+        self.editor.key_pressed.connect(self._on_key_pressed)
         self.widgetSearch.show()
         self.widgetReplace.hide()
         self.show()
@@ -290,6 +308,7 @@ class SearchAndReplacePanel(Panel, Ui_SearchPanel):
             self.request_search(new_text)
 
     def on_search_and_replace(self):
+        self.editor.key_pressed.connect(self._on_key_pressed)
         self.widgetSearch.show()
         self.widgetReplace.show()
         self.show()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [bdist_wheel]
 universal = 1
+
+[sdist_dsc]
+with-python2=true
+with-python3=true

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ from pyqode.core import __version__
 #   - pyqode-uic
 #
 import sys
+import os
+os.environ['DEB_BUILD_OPTIONS'] = 'nocheck'
 
 try:
     from pyqt_distutils.build_ui import build_ui

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,2 +1,9 @@
 [DEFAULT]
 Copyright-File: LICENSE
+Source=pyqode.core
+Package=python-pyqode.core
+Debian-version=1
+Suite=bionic
+Build-Depends=python-pyqode.qt, python3-pyqode.qt
+Depends=python-pyqode.qt
+Depends3=python3-pyqode.qt

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -4,6 +4,6 @@ Source=pyqode.core
 Package=python-pyqode.core
 Debian-version=1
 Suite=bionic
-Build-Depends=python-pyqode.qt, python3-pyqode.qt
+Build-Depends=python-pyqode.qt, python3-pyqode.qt, python-pytest, python3-pytest, python-pyqt5, python3-pyqt5, python-pygments, python3-pygments
 Depends=python-pyqode.qt
 Depends3=python3-pyqode.qt


### PR DESCRIPTION
The Escape key was bound to the search-replace panel, leading to the uncomfortable situation where the panel could not be closed by pressing Escape unless it was focused. This PR should fix that.