### PR TITLE
Improve debian/ ubuntu packaging

### DIFF
--- a/pyqode/core/__init__.py
+++ b/pyqode/core/__init__.py
@@ -10,7 +10,7 @@ widget, i.e. pyqode.core is a generic code editor widget.
 import logging
 
 
-__version__ = '2.12.2a4'
+__version__ = '2.12.2a8'
 
 
 logging.addLevelName(1, "PYQODEDEBUGCOMM")

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ from pyqode.core import __version__
 #   - pyqode-uic
 #
 import sys
+# Disable unit tests on local system when using stdeb3. This does not disable
+# tests on the launchpad build machines.
 import os
 os.environ['DEB_BUILD_OPTIONS'] = 'nocheck'
 
@@ -82,7 +84,7 @@ setup(
     entry_points={
         'console_scripts': [
             'pyqode-console = pyqode.core.tools.console:main'
-        ],
+        ] if sys.version_info[0] > 2 else [],  # To avoid Py2 v Py3 conflicts
         'pyqode_plugins':
             ['code_edit = pyqode.core._designer_plugins'],
         'pygments.styles':


### PR DESCRIPTION
Avoids building a console script for Python 2, such that Python 2 and 3 packages can co-exist.

(Sorry for bumping the version in the same commit. I suggest bumping 2.12.2 after merging the three current PRs.)